### PR TITLE
Moving the templates for K8S/OCP from tackle-controls

### DIFF
--- a/kubernetes/kubernetes-tackle.yaml
+++ b/kubernetes/kubernetes-tackle.yaml
@@ -2357,6 +2357,9 @@ spec:
               value: 'http://tackle-controls:8080'
             - name: APPLICATION_INVENTORY_API_URL
               value: 'http://tackle-application-inventory:8080'
+            - name: PATHFINDER_API_URL
+              # temporary and wrong value
+              value: 'http://tackle-controls:8080'
             - name: SSO_REALM
               value: quarkus
             - name: SSO_CLIENT_ID

--- a/kubernetes/kubernetes-tackle.yaml
+++ b/kubernetes/kubernetes-tackle.yaml
@@ -1,0 +1,2621 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: controls-postgresql
+  labels:
+    app.kubernetes.io/name: controls-postgresql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: controls-postgresql
+    app.kubernetes.io/part-of: tackle
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: application-inventory-postgresql
+  labels:
+    app.kubernetes.io/name: application-inventory-postgresql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: application-inventory-postgresql
+    app.kubernetes.io/part-of: tackle
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: keycloak-postgresql
+  labels:
+    app.kubernetes.io/name: keycloak-postgresql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: keycloak-postgresql
+    app.kubernetes.io/part-of: tackle
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: controls-postgresql
+  labels:
+    app.kubernetes.io/name: controls-postgresql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: controls-postgresql
+    app.kubernetes.io/part-of: tackle
+data:
+  database-name: Y29udHJvbHNfZGI=
+  database-password: Y29udHJvbHM=
+  database-user: Y29udHJvbHM=
+type: Opaque
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: application-inventory-postgresql
+  labels:
+    app.kubernetes.io/name: application-inventory-postgresql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: application-inventory-postgresql
+    app.kubernetes.io/part-of: tackle
+data:
+  database-name: YXBwbGljYXRpb25faW52ZW50b3J5X2Ri
+  database-password: YXBwbGljYXRpb25faW52ZW50b3J5
+  database-user: YXBwbGljYXRpb25faW52ZW50b3J5
+type: Opaque
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: keycloak-postgresql
+  labels:
+    app.kubernetes.io/name: keycloak-postgresql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: keycloak-postgresql
+    app.kubernetes.io/part-of: tackle
+data:
+  database-name: a2V5Y2xvYWs=
+  database-password: a2V5Y2xvYWs=
+  database-user: a2V5Y2xvYWs=
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: sso
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/part-of: tackle
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: keycloak
+# ???  type: LoadBalancer
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: keycloak-postgresql
+  labels:
+    app.kubernetes.io/name: keycloak-postgres
+    app.kubernetes.io/version: '10.6'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: keycloak-postgres
+    app.kubernetes.io/part-of: tackle
+spec:
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+  selector:
+    app.kubernetes.io/name: keycloak-postgres
+    app.kubernetes.io/version: '10.6'
+  type: ClusterIP
+  sessionAffinity: None
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: keycloak-postgres
+  labels:
+    app.kubernetes.io/name: keycloak-postgres
+    app.kubernetes.io/version: '10.6'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: keycloak-postgres
+    app.kubernetes.io/part-of: tackle
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak-postgres
+      app.kubernetes.io/version: '10.6'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: keycloak-postgres
+        app.kubernetes.io/version: '10.6'
+    spec:
+      volumes:
+        - name: keycloak-postgresql-data
+          persistentVolumeClaim:
+            claimName: keycloak-postgresql
+      containers:
+        - name: postgres
+          image: postgres:10.6
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-postgresql
+                  key: database-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-postgresql
+                  key: database-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-postgresql
+                  key: database-name
+          resources: {}
+          livenessProbe:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                - 'psql -U $POSTGRES_USER -d $POSTGRES_DB -c ''SELECT 1'' '
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                - 'psql -U $POSTGRES_USER -d $POSTGRES_DB -c ''SELECT 1'' '
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: keycloak-postgresql-data
+              mountPath: "/var/lib/postgresql"
+          securityContext:
+            privileged: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: sso
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/part-of: tackle
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: keycloak
+    spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: keycloak-realm
+        - name: theme-volume
+          emptyDir: {}
+      initContainers:
+        - name: keycloak-theme
+          image: busybox:stable
+          command:
+            - wget
+            - "-P"
+            - "deployments"
+            - "https://raw.githubusercontent.com/konveyor/tackle-keycloak-theme/main/tackle-keycloak-theme-0.1-SNAPSHOT.jar"
+          volumeMounts:
+            - name: theme-volume
+              mountPath: /deployments
+          imagePullPolicy: IfNotPresent
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:12.0.4
+          env:
+            - name: KEYCLOAK_USER
+              value: "admin"
+            - name: KEYCLOAK_PASSWORD
+              value: "admin"
+            - name: PROXY_ADDRESS_FORWARDING
+              value: "true"
+            - name: KEYCLOAK_IMPORT
+              value: /etc/config/quarkus-realm.json
+            - name: DB_VENDOR
+              value: postgres
+            - name: DB_ADDR
+              value: keycloak-postgresql
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-postgresql
+                  key: database-user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-postgresql
+                  key: database-password
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: https
+              containerPort: 8443
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: theme-volume
+              mountPath: /opt/jboss/keycloak/standalone/deployments
+          readinessProbe:
+            httpGet:
+              path: /auth/realms/master
+              port: 8080
+            initialDelaySeconds: 60
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /auth/realms/master
+              port: 8080
+            initialDelaySeconds: 120
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+---
+apiVersion: v1
+data:
+  quarkus-realm.json: |
+    {
+      "id" : "11d78bf6-6d10-4484-baba-a1388379d68b",
+      "realm" : "quarkus",
+      "loginTheme": "konveyor",
+      "notBefore" : 0,
+      "revokeRefreshToken" : false,
+      "refreshTokenMaxReuse" : 0,
+      "accessTokenLifespan" : 300,
+      "accessTokenLifespanForImplicitFlow" : 900,
+      "ssoSessionIdleTimeout" : 1800,
+      "ssoSessionMaxLifespan" : 36000,
+      "ssoSessionIdleTimeoutRememberMe" : 0,
+      "ssoSessionMaxLifespanRememberMe" : 0,
+      "offlineSessionIdleTimeout" : 2592000,
+      "offlineSessionMaxLifespanEnabled" : false,
+      "offlineSessionMaxLifespan" : 5184000,
+      "accessCodeLifespan" : 60,
+      "accessCodeLifespanUserAction" : 300,
+      "accessCodeLifespanLogin" : 1800,
+      "actionTokenGeneratedByAdminLifespan" : 43200,
+      "actionTokenGeneratedByUserLifespan" : 300,
+      "enabled" : true,
+      "sslRequired" : "external",
+      "registrationAllowed" : false,
+      "registrationEmailAsUsername" : false,
+      "rememberMe" : false,
+      "verifyEmail" : false,
+      "loginWithEmailAllowed" : true,
+      "duplicateEmailsAllowed" : false,
+      "resetPasswordAllowed" : false,
+      "editUsernameAllowed" : false,
+      "bruteForceProtected" : false,
+      "permanentLockout" : false,
+      "maxFailureWaitSeconds" : 900,
+      "minimumQuickLoginWaitSeconds" : 60,
+      "waitIncrementSeconds" : 60,
+      "quickLoginCheckMilliSeconds" : 1000,
+      "maxDeltaTimeSeconds" : 43200,
+      "failureFactor" : 30,
+      "roles" : {
+        "realm" : [ {
+          "id" : "3fc80564-13ac-4e7b-9986-322f571e82bc",
+          "name" : "confidential",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "11d78bf6-6d10-4484-baba-a1388379d68b",
+          "attributes" : { }
+        }, {
+          "id" : "39eb64c8-66a9-4983-9c81-27ea7e2f6273",
+          "name" : "uma_authorization",
+          "description" : "${role_uma_authorization}",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "11d78bf6-6d10-4484-baba-a1388379d68b",
+          "attributes" : { }
+        }, {
+          "id" : "8c1abe12-62fe-4a06-ae0d-f5fb67dddbb0",
+          "name" : "admin",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "11d78bf6-6d10-4484-baba-a1388379d68b",
+          "attributes" : { }
+        }, {
+          "id" : "5afce544-6a3c-495f-b805-fd737cf5081e",
+          "name" : "user",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "11d78bf6-6d10-4484-baba-a1388379d68b",
+          "attributes" : { }
+        }, {
+          "id" : "bc431d62-a80a-425b-961a-0fb3fc59006d",
+          "name" : "offline_access",
+          "description" : "${role_offline-access}",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "11d78bf6-6d10-4484-baba-a1388379d68b",
+          "attributes" : { }
+        } ],
+        "client" : {
+          "realm-management" : [ {
+            "id" : "7db1f38d-d436-4725-93fd-030a3bbe628e",
+            "name" : "manage-identity-providers",
+            "description" : "${role_manage-identity-providers}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "1163b9bd-7319-4154-a25f-0101b2548d21",
+            "name" : "impersonation",
+            "description" : "${role_impersonation}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "73d0a556-072b-404f-bf8e-10e2544c8c27",
+            "name" : "view-identity-providers",
+            "description" : "${role_view-identity-providers}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "7e727e28-2095-4443-b2da-865e684f2308",
+            "name" : "view-realm",
+            "description" : "${role_view-realm}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "df9e5352-f835-4467-bcaf-cb1b5f55c1ec",
+            "name" : "query-users",
+            "description" : "${role_query-users}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "fa77909a-32a3-41ae-9983-2b92ae03080c",
+            "name" : "manage-clients",
+            "description" : "${role_manage-clients}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "a8780507-dc72-4433-8b95-b8e4f3c37d0e",
+            "name" : "manage-events",
+            "description" : "${role_manage-events}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "f7f4697a-3977-42f6-af86-9bb006cf4d04",
+            "name" : "realm-admin",
+            "description" : "${role_realm-admin}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "realm-management" : [ "impersonation", "manage-identity-providers", "view-identity-providers", "view-realm", "query-users", "manage-clients", "manage-events", "manage-realm", "view-authorization", "manage-authorization", "view-users", "create-client", "query-clients", "query-groups", "manage-users", "view-clients", "view-events", "query-realms" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "ca7dc1ce-a981-4efe-b3f0-a7192b6d3943",
+            "name" : "manage-realm",
+            "description" : "${role_manage-realm}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "a0ab4faa-00a9-4f52-ac9f-8e764b6a8126",
+            "name" : "view-authorization",
+            "description" : "${role_view-authorization}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "0b4ed5e0-eceb-4d81-ba05-fa67022abe59",
+            "name" : "manage-authorization",
+            "description" : "${role_manage-authorization}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "c10336be-06f3-40ef-bef5-28d8c9b8a1e2",
+            "name" : "create-client",
+            "description" : "${role_create-client}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "1a1ffadc-11d5-44ea-bac0-d94372c8ae5c",
+            "name" : "view-users",
+            "description" : "${role_view-users}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "realm-management" : [ "query-groups", "query-users" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "5ba9a1a3-9027-4531-8253-b91f6058513c",
+            "name" : "query-clients",
+            "description" : "${role_query-clients}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "b4fba807-7a7e-4e3e-bd31-45703305a9e3",
+            "name" : "query-groups",
+            "description" : "${role_query-groups}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "c9384254-0af3-434c-b4ed-7c94f59a8247",
+            "name" : "manage-users",
+            "description" : "${role_manage-users}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "9a0022f2-bd58-4418-828c-a8e7abe3346b",
+            "name" : "view-clients",
+            "description" : "${role_view-clients}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "realm-management" : [ "query-clients" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "83df8311-4366-4d22-9425-eccc343faa3f",
+            "name" : "view-events",
+            "description" : "${role_view-events}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          }, {
+            "id" : "e81bf277-047f-4bdd-afd6-59e2016c5066",
+            "name" : "query-realms",
+            "description" : "${role_query-realms}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "376bd940-e50a-4495-80fc-9c6c07312748",
+            "attributes" : { }
+          } ],
+          "security-admin-console" : [ ],
+          "admin-cli" : [ ],
+          "tackle-ui": [],
+          "backend-service" : [ {
+            "id" : "df147a91-6da7-4bbc-866c-f30cf99b2637",
+            "name" : "uma_protection",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "0ac5df91-e044-4051-bd03-106a3a5fb9cc",
+            "attributes" : { }
+          } ],
+          "broker" : [ {
+            "id" : "d36865b0-7ade-4bcd-a7dc-1dacbd80f169",
+            "name" : "read-token",
+            "description" : "${role_read-token}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "53d4fe53-a039-471e-886a-28eddc950e95",
+            "attributes" : { }
+          } ],
+          "account" : [ {
+            "id" : "539325a0-d9b3-4821-97ee-d42999296b62",
+            "name" : "view-profile",
+            "description" : "${role_view-profile}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "e55e1234-38fa-432d-8d90-39f5e024688d",
+            "attributes" : { }
+          }, {
+            "id" : "e4af836c-c884-4a57-8b1d-fb673b0fe3a5",
+            "name" : "manage-account",
+            "description" : "${role_manage-account}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "account" : [ "manage-account-links" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "e55e1234-38fa-432d-8d90-39f5e024688d",
+            "attributes" : { }
+          }, {
+            "id" : "35d1c998-bcae-4ab1-a026-4c67bff49a98",
+            "name" : "manage-account-links",
+            "description" : "${role_manage-account-links}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "e55e1234-38fa-432d-8d90-39f5e024688d",
+            "attributes" : { }
+          } ]
+        }
+      },
+      "groups" : [ ],
+      "defaultRoles" : [ "uma_authorization", "offline_access" ],
+      "requiredCredentials" : [ "password" ],
+      "otpPolicyType" : "totp",
+      "otpPolicyAlgorithm" : "HmacSHA1",
+      "otpPolicyInitialCounter" : 0,
+      "otpPolicyDigits" : 6,
+      "otpPolicyLookAheadWindow" : 1,
+      "otpPolicyPeriod" : 30,
+      "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+      "scopeMappings" : [ {
+        "clientScope" : "offline_access",
+        "roles" : [ "offline_access" ]
+      } ],
+      "clients" : [ {
+        "id" : "e55e1234-38fa-432d-8d90-39f5e024688d",
+        "clientId" : "account",
+        "name" : "${client_account}",
+        "baseUrl" : "/auth/realms/quarkus/account",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "0136c3ef-0dfd-4b13-a6d0-2c8b6358edec",
+        "defaultRoles" : [ "view-profile", "manage-account" ],
+        "redirectUris" : [ "/auth/realms/quarkus/account/*" ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "e9cc41a2-8e35-4d5e-949e-4879880c2ddb",
+        "clientId" : "admin-cli",
+        "name" : "${client_admin-cli}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "a951803a-79c7-46a6-8197-e32835286971",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : false,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : true,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "53d4fe53-a039-471e-886a-28eddc950e95",
+        "clientId" : "broker",
+        "name" : "${client_broker}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "e1f7edd7-e15c-43b4-8736-ff8204d16836",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+      }, {
+          "id": "7f2cd8e2-dac3-41d8-b88b-bcd179f2bd39",
+          "clientId": "tackle-ui",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "**********",
+          "redirectUris": [
+            "*"
+          ],
+          "webOrigins": [
+            "*"
+          ],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "saml.assertion.signature": "false",
+            "saml.force.post.binding": "false",
+            "saml.multivalued.roles": "false",
+            "saml.encrypt": "false",
+            "backchannel.logout.revoke.offline.tokens": "false",
+            "saml.server.signature": "false",
+            "saml.server.signature.keyinfo.ext": "false",
+            "exclude.session.state.from.auth.response": "false",
+            "backchannel.logout.session.required": "true",
+            "client_credentials.use_refresh_token": "false",
+            "saml_force_name_id_format": "false",
+            "saml.client.signature": "false",
+            "tls.client.certificate.bound.access.tokens": "false",
+            "saml.authnstatement": "false",
+            "display.on.consent.screen": "false",
+            "saml.onetimeuse.condition": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": true,
+          "nodeReRegistrationTimeout": -1,
+          "defaultClientScopes": [
+            "web-origins",
+            "role_list",
+            "profile",
+            "roles",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        }, {
+        "id" : "0ac5df91-e044-4051-bd03-106a3a5fb9cc",
+        "clientId" : "backend-service",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : true,
+        "serviceAccountsEnabled" : true,
+        "authorizationServicesEnabled" : true,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : true,
+        "nodeReRegistrationTimeout" : -1,
+        "protocolMappers" : [ {
+          "id" : "3eac903f-c16b-4a78-a7e8-eb8f4d402b71",
+          "name" : "Client ID",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "clientId",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "clientId",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "8422cefe-7f42-4f3b-abad-5f06f7d4b748",
+          "name" : "Client IP Address",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "clientAddress",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "clientAddress",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "988e47d6-2055-45eb-82d6-0b8b25c629fc",
+          "name" : "Client Host",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "clientHost",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "clientHost",
+            "jsonType.label" : "String"
+          }
+        } ],
+        "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ],
+        "authorizationSettings" : {
+          "allowRemoteResourceManagement": true,
+          "policyEnforcementMode": "ENFORCING",
+          "resources": [
+            {
+              "name": "User Resource",
+              "ownerManagedAccess": false,
+              "attributes": {},
+              "_id": "df1b74a9-3f10-499d-a581-368de48e512b",
+              "uris": [
+                "/api/users/*"
+              ]
+            },
+            {
+              "name": "Administration Resource",
+              "ownerManagedAccess": false,
+              "attributes": {},
+              "_id": "7124e2f1-e6dc-44b4-87ab-24b010090b97",
+              "uris": [
+                "/api/admin/*"
+              ]
+            }
+          ],
+          "policies": [
+            {
+              "id": "b8710fa6-160e-4de0-adf3-398c7007a0af",
+              "name": "Any User Policy",
+              "description": "Any user granted with the user role can access something",
+              "type": "role",
+              "logic": "POSITIVE",
+              "decisionStrategy": "UNANIMOUS",
+              "config": {
+                "roles": "[{\"id\":\"user\",\"required\":false}]"
+              }
+            },
+            {
+              "id": "fcef30b2-68b2-4b78-9f3d-9162c6cdf5cb",
+              "name": "Only Administrators",
+              "description": "Only administrators can access",
+              "type": "role",
+              "logic": "POSITIVE",
+              "decisionStrategy": "UNANIMOUS",
+              "config": {
+                "roles": "[{\"id\":\"admin\",\"required\":false}]"
+              }
+            },
+            {
+              "id": "3479dd56-02e9-4222-94fe-6a13cd065195",
+              "name": "User Resource Permission",
+              "type": "resource",
+              "logic": "POSITIVE",
+              "decisionStrategy": "UNANIMOUS",
+              "config": {
+                "resources": "[\"User Resource\"]",
+                "applyPolicies": "[\"Any User Policy\"]"
+              }
+            },
+            {
+              "id": "60188298-d55b-4066-b231-6a7c56ff7cc5",
+              "name": "Administration Resource Permission",
+              "type": "resource",
+              "logic": "POSITIVE",
+              "decisionStrategy": "UNANIMOUS",
+              "config": {
+                "resources": "[\"Administration Resource\"]",
+                "applyPolicies": "[\"Only Administrators\"]"
+              }
+            }
+          ],
+          "scopes": [],
+          "decisionStrategy": "UNANIMOUS"
+        }
+      }, {
+        "id" : "376bd940-e50a-4495-80fc-9c6c07312748",
+        "clientId" : "realm-management",
+        "name" : "${client_realm-management}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "c41b709a-a012-4c69-89d7-4f926dba0619",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : true,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "a8732cac-ae0f-44ec-b7f3-bd2c41eff13c",
+        "clientId" : "security-admin-console",
+        "name" : "${client_security-admin-console}",
+        "baseUrl" : "/auth/admin/quarkus/console/index.html",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "e571b211-2550-475d-b87f-116ff54091ee",
+        "redirectUris" : [ "/auth/admin/quarkus/console/*" ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "protocolMappers" : [ {
+          "id" : "280528ca-5e96-4bb9-9fc0-20311caac32d",
+          "name" : "locale",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "locale",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "locale",
+            "jsonType.label" : "String"
+          }
+        } ],
+        "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+      } ],
+      "clientScopes" : [ {
+        "id" : "520cc3ef-2c6b-4d84-bcde-8c063241f4bd",
+        "name" : "address",
+        "description" : "OpenID Connect built-in scope: address",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "true",
+          "consent.screen.text" : "${addressScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+          "id" : "c1d3bd07-0a5f-4f4f-b381-c58a7b723029",
+          "name" : "address",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-address-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.attribute.formatted" : "formatted",
+            "user.attribute.country" : "country",
+            "user.attribute.postal_code" : "postal_code",
+            "userinfo.token.claim" : "true",
+            "user.attribute.street" : "street",
+            "id.token.claim" : "true",
+            "user.attribute.region" : "region",
+            "access.token.claim" : "true",
+            "user.attribute.locality" : "locality"
+          }
+        } ]
+      }, {
+        "id" : "19920c96-a383-4f35-8ee9-27833263cf03",
+        "name" : "email",
+        "description" : "OpenID Connect built-in scope: email",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "true",
+          "consent.screen.text" : "${emailScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+          "id" : "36a0adf0-6c25-419f-98d7-cdeada8661aa",
+          "name" : "email",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "email",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "email",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "b0c39901-5e5d-4436-b685-908bb90ea1d9",
+          "name" : "email verified",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "emailVerified",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "email_verified",
+            "jsonType.label" : "boolean"
+          }
+        } ]
+      }, {
+        "id" : "55b3ee1c-cbf9-4526-93d7-aa56a9c5f1cb",
+        "name" : "microprofile-jwt",
+        "description" : "Microprofile - JWT built-in scope",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "59128144-a21a-4744-bb55-e66ff0503b18",
+          "name" : "upn",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "username",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "upn",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "69351a63-7d6e-45d0-be47-088c83b20fdb",
+          "name" : "groups",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "multivalued" : "true",
+            "user.attribute" : "foo",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "groups",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "3f190f54-8e3a-4c82-a799-bd12ddc475b2",
+        "name" : "offline_access",
+        "description" : "OpenID Connect built-in scope: offline_access",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "consent.screen.text" : "${offlineAccessScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        }
+      }, {
+        "id" : "defa3480-5368-4f34-8075-49fb982b71b3",
+        "name" : "phone",
+        "description" : "OpenID Connect built-in scope: phone",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "true",
+          "consent.screen.text" : "${phoneScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+          "id" : "069ae414-9e98-4612-a3d6-e8b5a1fa841d",
+          "name" : "phone number verified",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "phoneNumberVerified",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "phone_number_verified",
+            "jsonType.label" : "boolean"
+          }
+        }, {
+          "id" : "cea58e24-d0e0-4cc6-9e34-7b3bf7d6d85b",
+          "name" : "phone number",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "phoneNumber",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "phone_number",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "b7321e2e-dd8e-41cf-a527-c765155c3f78",
+        "name" : "profile",
+        "description" : "OpenID Connect built-in scope: profile",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "true",
+          "consent.screen.text" : "${profileScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+          "id" : "1d4d3df5-7af5-488e-8477-0ad7cb74d50a",
+          "name" : "nickname",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "nickname",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "nickname",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "1a5e26d6-211e-4f8a-b696-0ea9577db25a",
+          "name" : "zoneinfo",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "zoneinfo",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "zoneinfo",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "18971685-6dd7-420f-9c09-879c4f2d54d8",
+          "name" : "updated at",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "updatedAt",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "updated_at",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "b970d96b-0156-4db0-9beb-9c84c173e619",
+          "name" : "birthdate",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "birthdate",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "birthdate",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "50287033-df21-45c6-aa46-c3060e6f9855",
+          "name" : "given name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "firstName",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "given_name",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "3dc6b97e-7063-4077-98d1-0cacf9029c7b",
+          "name" : "full name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-full-name-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "userinfo.token.claim" : "true"
+          }
+        }, {
+          "id" : "3fb9391b-376c-42ef-b012-4df461c617cc",
+          "name" : "middle name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "middleName",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "middle_name",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "83f7fc4a-5386-4f86-a103-6585e138b61d",
+          "name" : "username",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "username",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "preferred_username",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "8ef177b3-f485-44b1-afee-1901393b00c7",
+          "name" : "family name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "lastName",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "family_name",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "e994cbc7-2a1a-4465-b7b7-12b35b4fe49e",
+          "name" : "gender",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "gender",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "gender",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "abaa4c9e-1fa2-4b45-a1bb-b3d650de9aca",
+          "name" : "picture",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "picture",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "picture",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "bf21b514-81fd-4bbe-9236-bab5fcf54561",
+          "name" : "locale",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "locale",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "locale",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "254f8de4-08e7-4d3d-a87f-4b238f0f922b",
+          "name" : "profile",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "profile",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "profile",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "7934bf2a-cfc3-4b2d-a5cb-287f3ed2a977",
+          "name" : "website",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "website",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "website",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "f3dc793d-6011-4861-b538-399dde5434c0",
+        "name" : "role_list",
+        "description" : "SAML role list",
+        "protocol" : "saml",
+        "attributes" : {
+          "consent.screen.text" : "${samlRoleListScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "22eeabf8-a3c3-4026-a351-367f8ace7927",
+          "name" : "role list",
+          "protocol" : "saml",
+          "protocolMapper" : "saml-role-list-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "single" : "false",
+            "attribute.nameformat" : "Basic",
+            "attribute.name" : "Role"
+          }
+        } ]
+      }, {
+        "id" : "f72c1acd-c367-41b1-8646-b6bd5fff3e3f",
+        "name" : "roles",
+        "description" : "OpenID Connect scope for add user roles to the access token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "display.on.consent.screen" : "true",
+          "consent.screen.text" : "${rolesScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+          "id" : "cd8e589e-5fa7-4dae-bf6e-e8f6a3fd3cff",
+          "name" : "realm roles",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.attribute" : "foo",
+            "access.token.claim" : "true",
+            "claim.name" : "realm_access.roles",
+            "jsonType.label" : "String",
+            "multivalued" : "true"
+          }
+        }, {
+          "id" : "708b19d1-0709-4278-b5a1-bcbeec11f51a",
+          "name" : "audience resolve",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-audience-resolve-mapper",
+          "consentRequired" : false,
+          "config" : { }
+        }, {
+          "id" : "25e97210-30c7-4f35-be11-407f1fa674cb",
+          "name" : "client roles",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-client-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.attribute" : "foo",
+            "access.token.claim" : "true",
+            "claim.name" : "resource_access.${client_id}.roles",
+            "jsonType.label" : "String",
+            "multivalued" : "true"
+          }
+        } ]
+      }, {
+        "id" : "52618957-a4e8-4c6f-a902-217f2c41a2fd",
+        "name" : "web-origins",
+        "description" : "OpenID Connect scope for add allowed web origins to the access token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "display.on.consent.screen" : "false",
+          "consent.screen.text" : ""
+        },
+        "protocolMappers" : [ {
+          "id" : "a66ddadf-312f-491f-993c-fa58685815c6",
+          "name" : "allowed web origins",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-allowed-origins-mapper",
+          "consentRequired" : false,
+          "config" : { }
+        } ]
+      } ],
+      "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins" ],
+      "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+      "browserSecurityHeaders" : {
+        "contentSecurityPolicyReportOnly" : "",
+        "xContentTypeOptions" : "nosniff",
+        "xRobotsTag" : "none",
+        "xFrameOptions" : "SAMEORIGIN",
+        "xXSSProtection" : "1; mode=block",
+        "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+      },
+      "smtpServer" : { },
+      "eventsEnabled" : false,
+      "eventsListeners" : [ "jboss-logging" ],
+      "enabledEventTypes" : [ ],
+      "adminEventsEnabled" : false,
+      "adminEventsDetailsEnabled" : false,
+      "components" : {
+        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+          "id" : "a7679218-373d-48ca-88f8-429985faeae3",
+          "name" : "Allowed Protocol Mapper Types",
+          "providerId" : "allowed-protocol-mappers",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper" ]
+          }
+        }, {
+          "id" : "2ebf6f9f-4bfc-44b9-ad7c-282f2274d35b",
+          "name" : "Allowed Client Scopes",
+          "providerId" : "allowed-client-templates",
+          "subType" : "authenticated",
+          "subComponents" : { },
+          "config" : {
+            "allow-default-scopes" : [ "true" ]
+          }
+        }, {
+          "id" : "552093c3-0a0a-4234-ad7c-ae660f0f0db1",
+          "name" : "Allowed Client Scopes",
+          "providerId" : "allowed-client-templates",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "allow-default-scopes" : [ "true" ]
+          }
+        }, {
+          "id" : "8f27cf74-cee7-4a73-851f-982ee45157ca",
+          "name" : "Trusted Hosts",
+          "providerId" : "trusted-hosts",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "host-sending-registration-request-must-match" : [ "true" ],
+            "client-uris-must-match" : [ "true" ]
+          }
+        }, {
+          "id" : "ff570525-6c96-4500-9d73-c02e708b39de",
+          "name" : "Full Scope Disabled",
+          "providerId" : "scope",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : { }
+        }, {
+          "id" : "b52284eb-123a-4718-aac9-857530a24a9b",
+          "name" : "Max Clients Limit",
+          "providerId" : "max-clients",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "max-clients" : [ "200" ]
+          }
+        }, {
+          "id" : "2b8c0a6d-d5c0-4ea2-8a9c-4843d3e04ec6",
+          "name" : "Consent Required",
+          "providerId" : "consent-required",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : { }
+        }, {
+          "id" : "bf59de5a-2c93-43cc-a9aa-03be0129fe53",
+          "name" : "Allowed Protocol Mapper Types",
+          "providerId" : "allowed-protocol-mappers",
+          "subType" : "authenticated",
+          "subComponents" : { },
+          "config" : {
+            "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "oidc-full-name-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+          }
+        } ],
+        "org.keycloak.keys.KeyProvider" : [ {
+          "id" : "b3efd9cc-28b6-4404-82af-8a48a966b8ff",
+          "name" : "rsa-generated",
+          "providerId" : "rsa-generated",
+          "subComponents" : { },
+          "config" : {
+            "privateKey" : [ "MIIEowIBAAKCAQEAn5T13suF8mlS+pJXp0U1bto41nW55wpcs+Rps8ZVCRyJKWqzwSCYnI7lm0rB2wBpAAO4OPoj1zlmVoFmBPsDU9Xf7rjsJb5LIzIQDCZY44aSDZt6RR+gakPiQvlzHyW/RozYpngDJF7TsTD7rdRF1xQ4RprfBF8fwK/xsU7pxbeom5xDHZhz3fiw8s+7UdbmnazDHfAjU58aUrLGgVRfUsuoHjtsptYlOIXEifaeMetXZE+HhqLYRHQPDap5fbBJl773Trosn7N9nmzN4x1xxGj9So21WC5UboQs9sAIVgizc4omjZ5Y4RN9HLH7G4YwJctNntzmnJhDui9zAO+zSQIDAQABAoIBADi+F7rTtVoft0Cfnok8o6Y58/HVxHdxiMryUd95iy0FN4RBi48FTx6D9QKFz25Ws/8sU2n3D51srIXf1u24b1N0/f39RQKaqk7mcyxOylaEuBQcj5pah4ihgKd92UBfBKdKV5LBo6RgD3e2yhbiHr8+UlBQqzH7vOef6Bm6zIbfmi3N88swAJhP0YizRZFklsbmLsK6nkwyro00CHJvPVKSBbM+ad+/zIBsLw56MvNngB5TuFguUgoljd6M1T2z4utmZGlTUqrfE1onAVLJZoGnRohyIr7dJEg6YxWR70PxsgmkDKyeRvet9P1trO0n+OSprusfrC3cHJStabap1V0CgYEA1A/CtsqTnjdYYsB19eumZgdpzUgNc/YEAzZ/OWb8yTLoB2ncci+63A1rXHUXAqJFY7vtjn5mxv7SuASNbUrzq+6KfZvC1x9XEtnczqT/ypunNfxmIZuj8Nuu6vtURguZ8kPPwdkI8toTizRFeRE5ZDBvoQryiEVYugfHaHT5vzsCgYEAwKWODwquI0Lv9BuwdNVrBXQpkKh3ZfYOA7i9xvhxlM7xUu8OMCwwCPn3r7vrW5APjTqX4h330mJ44SLEs+7gbCUs4BbJBLA6g0ChlHa9PTkxp6tk2nDF/B34fxiZSRkE85L+d+at0Dc3hnlzLCJCzJawGpoPniPU9e4w0p4dN0sCgYAsGnMGjS8SUrRhJWHjGXVr9tK8TOXvXhULjgP7rj2Yoqu7Dvs4DFEyft/7RKbad2EzEtyfLA64CDtO5jN7rYDsGxpWcVSeZPg5BXJ0z8AbJTArfCjJiJMZ/rZsTIUEZFlKF2xYBolj6JLz+pUQTtK+0YwF1D8ItFN1rTR9twZSDQKBgQC6sPXNX+VH6LuPTjIf1x8CxwLs3EXxOpV0R9kp9GRl+HJnk6GlT30xhcThufQo5KAdllXQXIhoiuNoEoCbevhj9Vbax1oBQCNERSMRNEzKAx46xd9TzYwgeo7x5E3QR/3DaoVOfu+cY5ZcrF/PulgP2kxJS1mtQD5GIpGP2oinpwKBgGqiqTFPqRcelx76vBvTU+Jp1zM62T4AotbMrSQR/oUvqHe5Ytj/SbZx+wbbHAiyGgV700Mosyviik83YEAbR3kdOPjgYvAJJW2Y3jEMdQ7MwriXz8XLh5BGmYfVjkSOJXed9ua9WlYLKOJeXXv191BbDvrx5NXuJyVVU4vJx3YZ" ],
+            "certificate" : [ "MIICnTCCAYUCBgFp4EYIrjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdwcm90ZWFuMB4XDTE5MDQwMjIyNTYxOVoXDTI5MDQwMjIyNTc1OVowEjEQMA4GA1UEAwwHcHJvdGVhbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ+U9d7LhfJpUvqSV6dFNW7aONZ1uecKXLPkabPGVQkciSlqs8EgmJyO5ZtKwdsAaQADuDj6I9c5ZlaBZgT7A1PV3+647CW+SyMyEAwmWOOGkg2bekUfoGpD4kL5cx8lv0aM2KZ4AyRe07Ew+63URdcUOEaa3wRfH8Cv8bFO6cW3qJucQx2Yc934sPLPu1HW5p2swx3wI1OfGlKyxoFUX1LLqB47bKbWJTiFxIn2njHrV2RPh4ai2ER0Dw2qeX2wSZe+9066LJ+zfZ5szeMdccRo/UqNtVguVG6ELPbACFYIs3OKJo2eWOETfRyx+xuGMCXLTZ7c5pyYQ7ovcwDvs0kCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVtmRKDb4OK5iSA46tagMBkp6L7WuPpCWuHGWwobEP+BecYsShW7zP3s12oA8SNSwbhvu0CRqgzxhuypgf3hKQFVU153Erv4hzkj+8S0s5LR/ZE7tDNY2lzJ3yQKXy3Md7EkuzzvOZ50MTrcSKAanWq/ZW1OTnrtGymj5zGJnTg7mMnJzEIGePxkvPu/QdchiPBLqxfZYm1jsFGY25djOC3N/KmVcRVmPRGuu6D8tBFHlKoPfZYPdbMvsvs24aupHKRcZ+ofTCpK+2Qo8c0pSSqeEYHGmuGqC6lC6ozxtxSABPO9Q1R1tZBU7Kg5HvXUwwmoVS3EGub46YbHqbmWMLg==" ],
+            "priority" : [ "100" ]
+          }
+        }, {
+          "id" : "20460ca5-ec24-4a9b-839a-457743d3f841",
+          "name" : "hmac-generated",
+          "providerId" : "hmac-generated",
+          "subComponents" : { },
+          "config" : {
+            "kid" : [ "96afd00e-85cf-4d35-b18e-061d3813d8b2" ],
+            "secret" : [ "qBFGKdUGf6xDgKphnRfoFzIzaFHJW4bYnZ9MinPFzN38X5_ctq-2u1q5RdZzeJukXvk2biHB8_s3DxWmmLZFsA" ],
+            "priority" : [ "100" ],
+            "algorithm" : [ "HS256" ]
+          }
+        }, {
+          "id" : "4f02d984-7a23-4ce1-8591-848a71390efe",
+          "name" : "aes-generated",
+          "providerId" : "aes-generated",
+          "subComponents" : { },
+          "config" : {
+            "kid" : [ "b04473d3-8395-4016-b455-19a9e951106b" ],
+            "secret" : [ "x68mMOVdz3qKWzltzReV0g" ],
+            "priority" : [ "100" ]
+          }
+        } ]
+      },
+      "internationalizationEnabled" : false,
+      "supportedLocales" : [ ],
+      "authenticationFlows" : [ {
+        "id" : "d6c3e282-a738-4b8b-98c2-378b9faf8344",
+        "alias" : "Handle Existing Account",
+        "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "idp-confirm-link",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "idp-email-verification",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "flowAlias" : "Verify Existing Account by Re-authentication",
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : true
+        } ]
+      }, {
+        "id" : "4855860b-4009-4f1b-ba6b-60581618ea62",
+        "alias" : "Verify Existing Account by Re-authentication",
+        "description" : "Reauthentication of existing account",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "idp-username-password-form",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "auth-otp-form",
+          "requirement" : "OPTIONAL",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "8a9872b0-65f1-47ff-9565-fa826ac64cd4",
+        "alias" : "browser",
+        "description" : "browser based authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "auth-cookie",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "auth-spnego",
+          "requirement" : "DISABLED",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "identity-provider-redirector",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 25,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "flowAlias" : "forms",
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : true
+        } ]
+      }, {
+        "id" : "51b8ed14-62b6-49b3-b602-0b51508349e0",
+        "alias" : "clients",
+        "description" : "Base authentication for clients",
+        "providerId" : "client-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "client-secret",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "client-jwt",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "client-secret-jwt",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "client-x509",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 40,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "9b65133a-ee71-494a-a659-6804513fc30b",
+        "alias" : "direct grant",
+        "description" : "OpenID Connect Resource Owner Grant",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "direct-grant-validate-username",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "direct-grant-validate-password",
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "direct-grant-validate-otp",
+          "requirement" : "OPTIONAL",
+          "priority" : 30,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "f62bc4ad-25ac-4f83-963b-32820af3a683",
+        "alias" : "docker auth",
+        "description" : "Used by Docker clients to authenticate against the IDP",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "docker-http-basic-authenticator",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "1b423fe7-f312-404c-903b-f1260a77259b",
+        "alias" : "first broker login",
+        "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticatorConfig" : "review profile config",
+          "authenticator" : "idp-review-profile",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticatorConfig" : "create unique user config",
+          "authenticator" : "idp-create-user-if-unique",
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "flowAlias" : "Handle Existing Account",
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : true
+        } ]
+      }, {
+        "id" : "9c9530b3-e3c6-481b-99e8-1461a9752e8e",
+        "alias" : "forms",
+        "description" : "Username, password, otp and other auth forms.",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "auth-username-password-form",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "auth-otp-form",
+          "requirement" : "OPTIONAL",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "70fb94ac-354c-4629-a5fe-5135d0137964",
+        "alias" : "http challenge",
+        "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "no-cookie-redirect",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "basic-auth",
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "basic-auth-otp",
+          "requirement" : "DISABLED",
+          "priority" : 30,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "auth-spnego",
+          "requirement" : "DISABLED",
+          "priority" : 40,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "08292a4a-6722-4e33-a5d9-354c2628f567",
+        "alias" : "registration",
+        "description" : "registration flow",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "registration-page-form",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "flowAlias" : "registration form",
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : true
+        } ]
+      }, {
+        "id" : "668dc4b6-fe1a-4d24-ab5b-bc76e20ac390",
+        "alias" : "registration form",
+        "description" : "registration form",
+        "providerId" : "form-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "registration-user-creation",
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "registration-profile-action",
+          "requirement" : "REQUIRED",
+          "priority" : 40,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "registration-password-action",
+          "requirement" : "REQUIRED",
+          "priority" : 50,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "registration-recaptcha-action",
+          "requirement" : "DISABLED",
+          "priority" : 60,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "a0e191f0-ce9a-4a75-b6e4-97332b05f7e5",
+        "alias" : "reset credentials",
+        "description" : "Reset credentials for a user if they forgot their password or something",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "reset-credentials-choose-user",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "reset-credential-email",
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "reset-password",
+          "requirement" : "REQUIRED",
+          "priority" : 30,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        }, {
+          "authenticator" : "reset-otp",
+          "requirement" : "OPTIONAL",
+          "priority" : 40,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      }, {
+        "id" : "ad4beb21-8e9a-4fca-af41-0f757169f26c",
+        "alias" : "saml ecp",
+        "description" : "SAML ECP Profile Authentication Flow",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "http-basic-authenticator",
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "userSetupAllowed" : false,
+          "autheticatorFlow" : false
+        } ]
+      } ],
+      "authenticatorConfig" : [ {
+        "id" : "25632f91-6071-423a-8e9c-7322cdc1b011",
+        "alias" : "create unique user config",
+        "config" : {
+          "require.password.update.after.registration" : "false"
+        }
+      }, {
+        "id" : "02d7f70b-1ebc-4e72-a65c-d94a600895ac",
+        "alias" : "review profile config",
+        "config" : {
+          "update.profile.on.first.login" : "missing"
+        }
+      } ],
+      "requiredActions" : [ {
+        "alias" : "CONFIGURE_TOTP",
+        "name" : "Configure OTP",
+        "providerId" : "CONFIGURE_TOTP",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 10,
+        "config" : { }
+      }, {
+        "alias" : "terms_and_conditions",
+        "name" : "Terms and Conditions",
+        "providerId" : "terms_and_conditions",
+        "enabled" : false,
+        "defaultAction" : false,
+        "priority" : 20,
+        "config" : { }
+      }, {
+        "alias" : "UPDATE_PASSWORD",
+        "name" : "Update Password",
+        "providerId" : "UPDATE_PASSWORD",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 30,
+        "config" : { }
+      }, {
+        "alias" : "UPDATE_PROFILE",
+        "name" : "Update Profile",
+        "providerId" : "UPDATE_PROFILE",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 40,
+        "config" : { }
+      }, {
+        "alias" : "VERIFY_EMAIL",
+        "name" : "Verify Email",
+        "providerId" : "VERIFY_EMAIL",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 50,
+        "config" : { }
+      } ],
+      "browserFlow" : "browser",
+      "registrationFlow" : "registration",
+      "directGrantFlow" : "direct grant",
+      "resetCredentialsFlow" : "reset credentials",
+      "clientAuthenticationFlow" : "clients",
+      "dockerAuthenticationFlow" : "docker auth",
+      "attributes" : {
+        "_browser_header.xXSSProtection" : "1; mode=block",
+        "_browser_header.xFrameOptions" : "SAMEORIGIN",
+        "_browser_header.strictTransportSecurity" : "max-age=31536000; includeSubDomains",
+        "permanentLockout" : "false",
+        "quickLoginCheckMilliSeconds" : "1000",
+        "_browser_header.xRobotsTag" : "none",
+        "maxFailureWaitSeconds" : "900",
+        "minimumQuickLoginWaitSeconds" : "60",
+        "failureFactor" : "30",
+        "actionTokenGeneratedByUserLifespan" : "300",
+        "maxDeltaTimeSeconds" : "43200",
+        "_browser_header.xContentTypeOptions" : "nosniff",
+        "offlineSessionMaxLifespan" : "5184000",
+        "actionTokenGeneratedByAdminLifespan" : "43200",
+        "_browser_header.contentSecurityPolicyReportOnly" : "",
+        "bruteForceProtected" : "false",
+        "_browser_header.contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "waitIncrementSeconds" : "60",
+        "offlineSessionMaxLifespanEnabled" : "false"
+      },
+      "users" : [ {
+        "id" : "af134cab-f41c-4675-b141-205f975db679",
+        "username" : "admin",
+        "enabled" : true,
+        "totp" : false,
+        "emailVerified" : false,
+        "credentials" : [ {
+          "type" : "password",
+          "hashedSaltedValue" : "NICTtwsvSxJ5hL8hLAuleDUv9jwZcuXgxviMXvR++cciyPtiIEStEaJUyfA9DOir59awjPrHOumsclPVjNBplA==",
+          "salt" : "T/2P5o5oxFJUEk68BRURRg==",
+          "hashIterations" : 27500,
+          "counter" : 0,
+          "algorithm" : "pbkdf2-sha256",
+          "digits" : 0,
+          "period" : 0,
+          "createdDate" : 1554245879354,
+          "config" : { }
+        } ],
+        "disableableCredentialTypes" : [ "password" ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "admin", "user" ],
+        "notBefore" : 0,
+        "groups" : [ ]
+      }, {
+        "id" : "eb4123a3-b722-4798-9af5-8957f823657a",
+        "username" : "alice",
+        "enabled" : true,
+        "totp" : false,
+        "emailVerified" : false,
+        "credentials" : [ {
+          "type" : "password",
+          "hashedSaltedValue" : "A3okqV2T/ybXTVEgKfosoSjP8Yc9IZbFP/SY4cEd6hag7TABQrQ6nUSuwagGt96l8cw1DTijO75PqX6uiTXMzw==",
+          "salt" : "sl4mXx6T9FypPH/s9TngfQ==",
+          "hashIterations" : 27500,
+          "counter" : 0,
+          "algorithm" : "pbkdf2-sha256",
+          "digits" : 0,
+          "period" : 0,
+          "createdDate" : 1554245879116,
+          "config" : { }
+        } ],
+        "disableableCredentialTypes" : [ "password" ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "user" ],
+        "notBefore" : 0,
+        "groups" : [ ]
+      }, {
+        "id" : "1eed6a8e-a853-4597-b4c6-c4c2533546a0",
+        "username" : "jdoe",
+        "enabled" : true,
+        "totp" : false,
+        "emailVerified" : false,
+        "credentials" : [ {
+          "type" : "password",
+          "hashedSaltedValue" : "JV3DUNLjqOadjbBOtC4rvacQI553CGaDGAzBS8MR5ReCr7SwF3E6CsW3T7/XO8ITZAsch8+A/6loeuCoVLLJrg==",
+          "salt" : "uCbOH7HZtyDtMd0E9DG/nw==",
+          "hashIterations" : 27500,
+          "counter" : 0,
+          "algorithm" : "pbkdf2-sha256",
+          "digits" : 0,
+          "period" : 0,
+          "createdDate" : 1554245879227,
+          "config" : { }
+        } ],
+        "disableableCredentialTypes" : [ "password" ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "confidential", "user" ],
+        "notBefore" : 0,
+        "groups" : [ ]
+      }, {
+        "id" : "948c59ec-46ed-4d99-aa43-02900029b930",
+        "createdTimestamp" : 1554245880023,
+        "username" : "service-account-backend-service",
+        "enabled" : true,
+        "totp" : false,
+        "emailVerified" : false,
+        "email" : "service-account-backend-service@placeholder.org",
+        "serviceAccountClientId" : "backend-service",
+        "credentials" : [ ],
+        "disableableCredentialTypes" : [ ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "offline_access" ],
+        "clientRoles" : {
+          "backend-service" : [ "uma_protection" ],
+          "account" : [ "view-profile", "manage-account" ]
+        },
+        "notBefore" : 0,
+        "groups" : [ ]
+      } ],
+      "keycloakVersion" : "6.0.0",
+      "userManagedAccessAllowed" : false
+    }
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: sso
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/part-of: tackle
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: controls-postgresql
+  labels:
+    app.kubernetes.io/name: controls-postgres
+    app.kubernetes.io/version: '10.6'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: controls-postgres
+    app.kubernetes.io/part-of: tackle
+spec:
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+  selector:
+    app.kubernetes.io/name: controls-postgres
+    app.kubernetes.io/version: '10.6'
+  type: ClusterIP
+  sessionAffinity: None
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: application-inventory-postgresql
+  labels:
+    app.kubernetes.io/name: application-inventory-postgres
+    app.kubernetes.io/version: '10.6'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: application-inventory-postgres
+    app.kubernetes.io/part-of: tackle
+spec:
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+  selector:
+    app.kubernetes.io/name: application-inventory-postgres
+    app.kubernetes.io/version: '10.6'
+  type: ClusterIP
+  sessionAffinity: None
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: controls-postgres
+  labels:
+    app.kubernetes.io/name: controls-postgres
+    app.kubernetes.io/version: '10.6'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: controls-postgres
+    app.kubernetes.io/part-of: tackle
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controls-postgres
+      app.kubernetes.io/version: '10.6'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controls-postgres
+        app.kubernetes.io/version: '10.6'
+    spec:
+      volumes:
+        - name: controls-postgresql-data
+          persistentVolumeClaim:
+            claimName: controls-postgresql
+      containers:
+        - name: postgres
+          image: 'postgres:10.6'
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: controls-postgresql
+                  key: database-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: controls-postgresql
+                  key: database-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: controls-postgresql
+                  key: database-name
+          resources: {}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-c"
+                - |
+                  psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-c"
+                - |
+                  psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: controls-postgresql-data
+              mountPath: /var/lib/postgresql
+          securityContext:
+            privileged: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: application-inventory-postgres
+  labels:
+    app.kubernetes.io/name: application-inventory-postgres
+    app.kubernetes.io/version: '10.6'
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: application-inventory-postgres
+    app.kubernetes.io/part-of: tackle
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: application-inventory-postgres
+      app.kubernetes.io/version: '10.6'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: application-inventory-postgres
+        app.kubernetes.io/version: '10.6'
+    spec:
+      volumes:
+        - name: application-inventory-postgresql-data
+          persistentVolumeClaim:
+            claimName: application-inventory-postgresql
+      containers:
+        - name: postgres
+          image: postgres:10.6
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: application-inventory-postgresql
+                  key: database-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: application-inventory-postgresql
+                  key: database-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: application-inventory-postgresql
+                  key: database-name
+          resources: {}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-c"
+                - |
+                  psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-c"
+                - |
+                  psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: application-inventory-postgresql-data
+              mountPath: "/var/lib/postgresql"
+          securityContext:
+            privileged: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: tackle
+  labels:
+    app.kubernetes.io/name: tackle
+    app.kubernetes.io/component: application
+    app.kubernetes.io/instance: tackle
+    app.kubernetes.io/part-of: tackle
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: tackle-ui
+                port:
+                  number: 8080
+---
+#kind: Ingress
+#apiVersion: networking.k8s.io/v1beta1
+#metadata:
+#  name: tackle
+#  labels:
+#    app.kubernetes.io/name: tackle
+#    app.kubernetes.io/component: application
+#    app.kubernetes.io/instance: tackle
+#    app.kubernetes.io/part-of: tackle
+#spec:
+#  rules:
+#    - http:
+#        paths:
+#          - path: /
+#            pathType: ImplementationSpecific
+#            backend:
+#              serviceName: tackle-ui
+#              servicePort: 8080
+#---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: tackle-ui
+  labels:
+    app.kubernetes.io/name: tackle-ui
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: tackle-ui
+    app.kubernetes.io/part-of: tackle
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tackle-ui
+      app.kubernetes.io/instance: tackle-ui
+      app.kubernetes.io/part-of: tackle
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tackle-ui
+        app.kubernetes.io/instance: tackle-ui
+        app.kubernetes.io/part-of: tackle
+    spec:
+      containers:
+        - name: tackle-ui
+          image: quay.io/konveyor/tackle-ui:main
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+          env:
+            - name: CONTROLS_API_URL
+              value: 'http://tackle-controls:8080'
+            - name: APPLICATION_INVENTORY_API_URL
+              value: 'http://tackle-application-inventory:8080'
+            - name: SSO_REALM
+              value: quarkus
+            - name: SSO_CLIENT_ID
+              value: tackle-ui
+            - name: SSO_SERVER_URL
+              value: 'http://keycloak:8080'
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "[ -f /run/nginx.pid ] && ps -A | grep nginx"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: tackle-ui
+  labels:
+    app.kubernetes.io/name: tackle-ui
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: tackle-ui
+    app.kubernetes.io/part-of: tackle
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: tackle-ui
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+  labels:
+    app.kubernetes.io/name: tackle-controls
+    app.kubernetes.io/part-of: tackle
+    app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+    app.kubernetes.io/component: rest
+  name: tackle-controls
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: tackle-controls
+    app.kubernetes.io/part-of: tackle
+    app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scheme: http
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: "/q/metrics"
+    prometheus.io/port: '8080'
+  labels:
+    app.kubernetes.io/name: tackle-application-inventory
+    app.kubernetes.io/part-of: tackle
+    app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+    app.kubernetes.io/component: rest
+    app.openshift.io/runtime: quarkus
+  name: tackle-application-inventory
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: tackle-application-inventory
+    app.kubernetes.io/part-of: tackle
+    app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+  labels:
+    app.kubernetes.io/component: rest
+    app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+    app.kubernetes.io/name: tackle-controls
+    app.kubernetes.io/part-of: tackle
+  name: tackle-controls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+      app.kubernetes.io/name: tackle-controls
+      app.kubernetes.io/part-of: tackle
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+      labels:
+        app.kubernetes.io/component: rest
+        app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+        app.kubernetes.io/name: tackle-controls
+        app.kubernetes.io/part-of: tackle
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: QUARKUS_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: controls-postgresql
+                  key: database-user
+            - name: QUARKUS_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: controls-postgresql
+                  key: database-password
+          image: quay.io/konveyor/tackle-controls:0.0.1-SNAPSHOT-native
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /controls/q/health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: tackle-controls
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /controls/q/health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/port: '8080'
+    prometheus.io/scheme: http
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: "/q/metrics"
+  labels:
+    app.kubernetes.io/component: rest
+    app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+    app.kubernetes.io/name: tackle-application-inventory
+    app.kubernetes.io/part-of: tackle
+  name: tackle-application-inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+      app.kubernetes.io/name: tackle-application-inventory
+      app.kubernetes.io/part-of: tackle
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '8080'
+        prometheus.io/scheme: http
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: "/q/metrics"
+      labels:
+        app.kubernetes.io/component: rest
+        app.kubernetes.io/version: 0.0.1-SNAPSHOT-native
+        app.kubernetes.io/name: tackle-application-inventory
+        app.kubernetes.io/part-of: tackle
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: QUARKUS_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: application-inventory-postgresql
+                  key: database-user
+            - name: QUARKUS_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: application-inventory-postgresql
+                  key: database-password
+          image: quay.io/konveyor/tackle-application-inventory:0.0.1-SNAPSHOT-native
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/application-inventory/q/health/live"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: tackle-application-inventory
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/application-inventory/q/health/ready"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10

--- a/kubernetes/openshift-tackle.json
+++ b/kubernetes/openshift-tackle.json
@@ -966,6 +966,10 @@
                     "value": "http://tackle-application-inventory:8080"
                   },
                   {
+                    "name": "PATHFINDER_API_URL",
+                    "value": "http://tackle-controls:8080"
+                  },
+                  {
                     "name": "SSO_REALM",
                     "value": "quarkus"
                   },

--- a/kubernetes/openshift-tackle.json
+++ b/kubernetes/openshift-tackle.json
@@ -1,0 +1,1356 @@
+{
+  "kind": "Template",
+  "apiVersion": "template.openshift.io/v1",
+  "metadata": {
+    "annotations": {
+      "description": "Tackle template",
+      "openshift.io/display-name": "Tackle (Konveyor)",
+      "iconClass": "fas fa-boxes"
+    },
+    "name": "tackle"
+  },
+  "labels": {
+    "app.kubernetes.io/name": "tackle",
+    "app.kubernetes.io/component": "template",
+    "app.kubernetes.io/instance": "tackle",
+    "app.kubernetes.io/part-of": "tackle"
+  },
+  "message": "Tackle has been installed. The username/password for accessing the PostgreSQL database is ${CONTROLS_DATASOURCE_USERNAME}/${CONTROLS_DATASOURCE_PASSWORD}.",
+  "parameters": [
+    {
+      "displayName": "Controls REST container images",
+      "description": "The value of the Controls REST container image to be used",
+      "name": "CONTROLS_REST_CONTAINER_IMAGE",
+      "value": "quay.io/konveyor/tackle-controls:0.0.1-SNAPSHOT-native",
+      "required": true
+    },
+    {
+      "displayName": "Controls UI container images",
+      "description": "The value of the Controls UI container image to be used",
+      "name": "CONTROLS_UI_CONTAINER_IMAGE",
+      "value": "quay.io/konveyor/tackle-ui:main",
+      "required": true
+    },
+    {
+      "displayName": "Application Inventory REST container images",
+      "description": "The value of the Application Inventory REST container image to be used",
+      "name": "APPLICATION_INVENTORY_REST_CONTAINER_IMAGE",
+      "value": "quay.io/konveyor/tackle-application-inventory:0.0.1-SNAPSHOT-native",
+      "required": true
+    },
+    {
+      "displayName": "Controls Database Username",
+      "description": "Controls database user name",
+      "name": "CONTROLS_DATASOURCE_USERNAME",
+      "from": "user[a-zA-Z0-9]{3}",
+      "generate": "expression",
+      "required": true
+    },
+    {
+      "displayName": "Controls Database Password",
+      "description": "Controls database user password",
+      "name": "CONTROLS_DATASOURCE_PASSWORD",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "required": true
+    },
+    {
+      "displayName": "Application Inventory Database Username",
+      "description": "Application Inventory database user name",
+      "name": "APPLICATION_INVENTORY_DATASOURCE_USERNAME",
+      "from": "user[a-zA-Z0-9]{3}",
+      "generate": "expression",
+      "required": true
+    },
+    {
+      "displayName": "Application Inventory Database Password",
+      "description": "Application Inventory database user password",
+      "name": "APPLICATION_INVENTORY_DATASOURCE_PASSWORD",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "required": true
+    },
+    {
+      "displayName": "Keycloak Database Username",
+      "description": "Keycloak database user name",
+      "name": "KEYCLOAK_DATASOURCE_USERNAME",
+      "from": "user[a-zA-Z0-9]{3}",
+      "generate": "expression",
+      "required": true
+    },
+    {
+      "displayName": "Keycloak Database Password",
+      "description": "Keycloak database user password",
+      "name": "KEYCLOAK_DATASOURCE_PASSWORD",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "required": true
+    }
+  ],
+  "objects": [
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "controls-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "controls-postgresql",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "controls-postgresql",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "1Gi"
+          }
+        },
+        "volumeMode": "Filesystem"
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "application-inventory-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "application-inventory-postgresql",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "application-inventory-postgresql",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "1Gi"
+          }
+        },
+        "volumeMode": "Filesystem"
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "keycloak-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak-postgresql",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "keycloak-postgresql",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "1Gi"
+          }
+        },
+        "volumeMode": "Filesystem"
+      }
+    },
+    {
+      "kind": "Secret",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "controls-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "controls-postgresql",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "controls-postgresql",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "stringData": {
+        "database-name": "controls_db",
+        "database-password": "${CONTROLS_DATASOURCE_PASSWORD}",
+        "database-user": "${CONTROLS_DATASOURCE_USERNAME}"
+      },
+      "type": "Opaque"
+    },
+    {
+      "kind": "Secret",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "application-inventory-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "application-inventory-postgresql",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "application-inventory-postgresql",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "stringData": {
+        "database-name": "application_inventory_db",
+        "database-password": "${APPLICATION_INVENTORY_DATASOURCE_USERNAME}",
+        "database-user": "${APPLICATION_INVENTORY_DATASOURCE_USERNAME}"
+      },
+      "type": "Opaque"
+    },
+    {
+      "kind": "Secret",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "keycloak-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak-postgresql",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "keycloak-postgresql",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "stringData": {
+        "database-name": "keycloak",
+        "database-password": "${KEYCLOAK_DATASOURCE_PASSWORD}",
+        "database-user": "${KEYCLOAK_DATASOURCE_USERNAME}"
+      },
+      "type": "Opaque"
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "keycloak-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak-postgres",
+          "app.kubernetes.io/version": "10.6",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "keycloak-postgres",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "tcp",
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 5432
+          }
+        ],
+        "selector": {
+          "app.kubernetes.io/name": "keycloak-postgres",
+          "app.kubernetes.io/version": "10.6"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "keycloak-postgres",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak-postgres",
+          "app.kubernetes.io/version": "10.6",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "keycloak-postgres",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app.kubernetes.io/name": "keycloak-postgres",
+            "app.kubernetes.io/version": "10.6"
+          }
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "keycloak-postgres",
+              "app.kubernetes.io/version": "10.6"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "keycloak-postgresql-data",
+                "persistentVolumeClaim": {
+                  "claimName": "keycloak-postgresql"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "postgres",
+                "image": "postgres:10.6",
+                "ports": [
+                  {
+                    "containerPort": 5432,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "POSTGRES_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "keycloak-postgresql",
+                        "key": "database-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "keycloak-postgresql",
+                        "key": "database-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_DB",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "keycloak-postgresql",
+                        "key": "database-name"
+                      }
+                    }
+                  }
+                ],
+                "resources": {},
+                "livenessProbe": {
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'\n"
+                    ]
+                  },
+                  "initialDelaySeconds": 60,
+                  "timeoutSeconds": 10,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "readinessProbe": {
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'\n"
+                    ]
+                  },
+                  "initialDelaySeconds": 10,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "IfNotPresent",
+                "volumeMounts": [
+                  {
+                    "name": "keycloak-postgresql-data",
+                    "mountPath": "/var/lib/postgresql"
+                  }
+                ],
+                "securityContext": {
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "securityContext": {},
+            "schedulerName": "default-scheduler"
+          }
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": "25%",
+            "maxSurge": "25%"
+          }
+        },
+        "revisionHistoryLimit": 10,
+        "progressDeadlineSeconds": 600
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "keycloak",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak",
+          "app.kubernetes.io/component": "sso",
+          "app.kubernetes.io/instance": "keycloak",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "http",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app.kubernetes.io/name": "keycloak"
+        }
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "keycloak",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak",
+          "app.kubernetes.io/component": "sso",
+          "app.kubernetes.io/instance": "keycloak",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app.kubernetes.io/name": "keycloak"
+          }
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "keycloak"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "config-volume",
+                "configMap": {
+                  "name": "keycloak-realm"
+                }
+              },
+              {
+                "name": "theme-volume",
+                "emptyDir": {}
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "keycloak-theme",
+                "image": "busybox:stable",
+                "command": [
+                  "wget",
+                  "-P",
+                  "deployments",
+                  "https://raw.githubusercontent.com/konveyor/tackle-keycloak-theme/main/tackle-keycloak-theme-0.1-SNAPSHOT.jar"
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "theme-volume",
+                    "mountPath": "/deployments"
+                  }
+                ],
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "containers": [
+              {
+                "name": "keycloak",
+                "image": "quay.io/keycloak/keycloak:12.0.4",
+                "env": [
+                  {
+                    "name": "KEYCLOAK_USER",
+                    "value": "admin"
+                  },
+                  {
+                    "name": "KEYCLOAK_PASSWORD",
+                    "value": "admin"
+                  },
+                  {
+                    "name": "PROXY_ADDRESS_FORWARDING",
+                    "value": "true"
+                  },
+                  {
+                    "name": "KEYCLOAK_IMPORT",
+                    "value": "/etc/config/quarkus-realm.json"
+                  },
+                  {
+                    "name": "DB_VENDOR",
+                    "value": "postgres"
+                  },
+                  {
+                    "name": "DB_ADDR",
+                    "value": "keycloak-postgresql"
+                  },
+                  {
+                    "name": "DB_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "keycloak-postgresql",
+                        "key": "database-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "DB_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "keycloak-postgresql",
+                        "key": "database-password"
+                      }
+                    }
+                  }
+                ],
+                "ports": [
+                  {
+                    "name": "http",
+                    "containerPort": 8080
+                  },
+                  {
+                    "name": "https",
+                    "containerPort": 8443
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "config-volume",
+                    "mountPath": "/etc/config"
+                  },
+                  {
+                    "name": "theme-volume",
+                    "mountPath": "/opt/jboss/keycloak/standalone/deployments"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/auth/realms/master",
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 60,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 6
+                },
+                "livenessProbe": {
+                  "httpGet": {
+                    "path": "/auth/realms/master",
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 120,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 6
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "data": {
+        "quarkus-realm.json": "{\n  \"id\" : \"11d78bf6-6d10-4484-baba-a1388379d68b\",\n  \"realm\" : \"quarkus\",\n \"loginTheme\" : \"konveyor\",\n  \"notBefore\" : 0,\n  \"revokeRefreshToken\" : false,\n  \"refreshTokenMaxReuse\" : 0,\n  \"accessTokenLifespan\" : 300,\n  \"accessTokenLifespanForImplicitFlow\" : 900,\n  \"ssoSessionIdleTimeout\" : 1800,\n  \"ssoSessionMaxLifespan\" : 36000,\n  \"ssoSessionIdleTimeoutRememberMe\" : 0,\n  \"ssoSessionMaxLifespanRememberMe\" : 0,\n  \"offlineSessionIdleTimeout\" : 2592000,\n  \"offlineSessionMaxLifespanEnabled\" : false,\n  \"offlineSessionMaxLifespan\" : 5184000,\n  \"accessCodeLifespan\" : 60,\n  \"accessCodeLifespanUserAction\" : 300,\n  \"accessCodeLifespanLogin\" : 1800,\n  \"actionTokenGeneratedByAdminLifespan\" : 43200,\n  \"actionTokenGeneratedByUserLifespan\" : 300,\n  \"enabled\" : true,\n  \"sslRequired\" : \"external\",\n  \"registrationAllowed\" : false,\n  \"registrationEmailAsUsername\" : false,\n  \"rememberMe\" : false,\n  \"verifyEmail\" : false,\n  \"loginWithEmailAllowed\" : true,\n  \"duplicateEmailsAllowed\" : false,\n  \"resetPasswordAllowed\" : false,\n  \"editUsernameAllowed\" : false,\n  \"bruteForceProtected\" : false,\n  \"permanentLockout\" : false,\n  \"maxFailureWaitSeconds\" : 900,\n  \"minimumQuickLoginWaitSeconds\" : 60,\n  \"waitIncrementSeconds\" : 60,\n  \"quickLoginCheckMilliSeconds\" : 1000,\n  \"maxDeltaTimeSeconds\" : 43200,\n  \"failureFactor\" : 30,\n  \"roles\" : {\n    \"realm\" : [ {\n      \"id\" : \"3fc80564-13ac-4e7b-9986-322f571e82bc\",\n      \"name\" : \"confidential\",\n      \"composite\" : false,\n      \"clientRole\" : false,\n      \"containerId\" : \"11d78bf6-6d10-4484-baba-a1388379d68b\",\n      \"attributes\" : { }\n    }, {\n      \"id\" : \"39eb64c8-66a9-4983-9c81-27ea7e2f6273\",\n      \"name\" : \"uma_authorization\",\n      \"description\" : \"${role_uma_authorization}\",\n      \"composite\" : false,\n      \"clientRole\" : false,\n      \"containerId\" : \"11d78bf6-6d10-4484-baba-a1388379d68b\",\n      \"attributes\" : { }\n    }, {\n      \"id\" : \"8c1abe12-62fe-4a06-ae0d-f5fb67dddbb0\",\n      \"name\" : \"admin\",\n      \"composite\" : false,\n      \"clientRole\" : false,\n      \"containerId\" : \"11d78bf6-6d10-4484-baba-a1388379d68b\",\n      \"attributes\" : { }\n    }, {\n      \"id\" : \"5afce544-6a3c-495f-b805-fd737cf5081e\",\n      \"name\" : \"user\",\n      \"composite\" : false,\n      \"clientRole\" : false,\n      \"containerId\" : \"11d78bf6-6d10-4484-baba-a1388379d68b\",\n      \"attributes\" : { }\n    }, {\n      \"id\" : \"bc431d62-a80a-425b-961a-0fb3fc59006d\",\n      \"name\" : \"offline_access\",\n      \"description\" : \"${role_offline-access}\",\n      \"composite\" : false,\n      \"clientRole\" : false,\n      \"containerId\" : \"11d78bf6-6d10-4484-baba-a1388379d68b\",\n      \"attributes\" : { }\n    } ],\n    \"client\" : {\n      \"realm-management\" : [ {\n        \"id\" : \"7db1f38d-d436-4725-93fd-030a3bbe628e\",\n        \"name\" : \"manage-identity-providers\",\n        \"description\" : \"${role_manage-identity-providers}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"1163b9bd-7319-4154-a25f-0101b2548d21\",\n        \"name\" : \"impersonation\",\n        \"description\" : \"${role_impersonation}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"73d0a556-072b-404f-bf8e-10e2544c8c27\",\n        \"name\" : \"view-identity-providers\",\n        \"description\" : \"${role_view-identity-providers}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"7e727e28-2095-4443-b2da-865e684f2308\",\n        \"name\" : \"view-realm\",\n        \"description\" : \"${role_view-realm}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"df9e5352-f835-4467-bcaf-cb1b5f55c1ec\",\n        \"name\" : \"query-users\",\n        \"description\" : \"${role_query-users}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"fa77909a-32a3-41ae-9983-2b92ae03080c\",\n        \"name\" : \"manage-clients\",\n        \"description\" : \"${role_manage-clients}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"a8780507-dc72-4433-8b95-b8e4f3c37d0e\",\n        \"name\" : \"manage-events\",\n        \"description\" : \"${role_manage-events}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"f7f4697a-3977-42f6-af86-9bb006cf4d04\",\n        \"name\" : \"realm-admin\",\n        \"description\" : \"${role_realm-admin}\",\n        \"composite\" : true,\n        \"composites\" : {\n          \"client\" : {\n            \"realm-management\" : [ \"impersonation\", \"manage-identity-providers\", \"view-identity-providers\", \"view-realm\", \"query-users\", \"manage-clients\", \"manage-events\", \"manage-realm\", \"view-authorization\", \"manage-authorization\", \"view-users\", \"create-client\", \"query-clients\", \"query-groups\", \"manage-users\", \"view-clients\", \"view-events\", \"query-realms\" ]\n          }\n        },\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"ca7dc1ce-a981-4efe-b3f0-a7192b6d3943\",\n        \"name\" : \"manage-realm\",\n        \"description\" : \"${role_manage-realm}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"a0ab4faa-00a9-4f52-ac9f-8e764b6a8126\",\n        \"name\" : \"view-authorization\",\n        \"description\" : \"${role_view-authorization}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"0b4ed5e0-eceb-4d81-ba05-fa67022abe59\",\n        \"name\" : \"manage-authorization\",\n        \"description\" : \"${role_manage-authorization}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"c10336be-06f3-40ef-bef5-28d8c9b8a1e2\",\n        \"name\" : \"create-client\",\n        \"description\" : \"${role_create-client}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"1a1ffadc-11d5-44ea-bac0-d94372c8ae5c\",\n        \"name\" : \"view-users\",\n        \"description\" : \"${role_view-users}\",\n        \"composite\" : true,\n        \"composites\" : {\n          \"client\" : {\n            \"realm-management\" : [ \"query-groups\", \"query-users\" ]\n          }\n        },\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"5ba9a1a3-9027-4531-8253-b91f6058513c\",\n        \"name\" : \"query-clients\",\n        \"description\" : \"${role_query-clients}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"b4fba807-7a7e-4e3e-bd31-45703305a9e3\",\n        \"name\" : \"query-groups\",\n        \"description\" : \"${role_query-groups}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"c9384254-0af3-434c-b4ed-7c94f59a8247\",\n        \"name\" : \"manage-users\",\n        \"description\" : \"${role_manage-users}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"9a0022f2-bd58-4418-828c-a8e7abe3346b\",\n        \"name\" : \"view-clients\",\n        \"description\" : \"${role_view-clients}\",\n        \"composite\" : true,\n        \"composites\" : {\n          \"client\" : {\n            \"realm-management\" : [ \"query-clients\" ]\n          }\n        },\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"83df8311-4366-4d22-9425-eccc343faa3f\",\n        \"name\" : \"view-events\",\n        \"description\" : \"${role_view-events}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"e81bf277-047f-4bdd-afd6-59e2016c5066\",\n        \"name\" : \"query-realms\",\n        \"description\" : \"${role_query-realms}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n        \"attributes\" : { }\n      } ],\n      \"security-admin-console\" : [ ],\n      \"admin-cli\" : [ ],\n      \"tackle-ui\": [],\n      \"backend-service\" : [ {\n        \"id\" : \"df147a91-6da7-4bbc-866c-f30cf99b2637\",\n        \"name\" : \"uma_protection\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"0ac5df91-e044-4051-bd03-106a3a5fb9cc\",\n        \"attributes\" : { }\n      } ],\n      \"broker\" : [ {\n        \"id\" : \"d36865b0-7ade-4bcd-a7dc-1dacbd80f169\",\n        \"name\" : \"read-token\",\n        \"description\" : \"${role_read-token}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"53d4fe53-a039-471e-886a-28eddc950e95\",\n        \"attributes\" : { }\n      } ],\n      \"account\" : [ {\n        \"id\" : \"539325a0-d9b3-4821-97ee-d42999296b62\",\n        \"name\" : \"view-profile\",\n        \"description\" : \"${role_view-profile}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"e55e1234-38fa-432d-8d90-39f5e024688d\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"e4af836c-c884-4a57-8b1d-fb673b0fe3a5\",\n        \"name\" : \"manage-account\",\n        \"description\" : \"${role_manage-account}\",\n        \"composite\" : true,\n        \"composites\" : {\n          \"client\" : {\n            \"account\" : [ \"manage-account-links\" ]\n          }\n        },\n        \"clientRole\" : true,\n        \"containerId\" : \"e55e1234-38fa-432d-8d90-39f5e024688d\",\n        \"attributes\" : { }\n      }, {\n        \"id\" : \"35d1c998-bcae-4ab1-a026-4c67bff49a98\",\n        \"name\" : \"manage-account-links\",\n        \"description\" : \"${role_manage-account-links}\",\n        \"composite\" : false,\n        \"clientRole\" : true,\n        \"containerId\" : \"e55e1234-38fa-432d-8d90-39f5e024688d\",\n        \"attributes\" : { }\n      } ]\n    }\n  },\n  \"groups\" : [ ],\n  \"defaultRoles\" : [ \"uma_authorization\", \"offline_access\" ],\n  \"requiredCredentials\" : [ \"password\" ],\n  \"otpPolicyType\" : \"totp\",\n  \"otpPolicyAlgorithm\" : \"HmacSHA1\",\n  \"otpPolicyInitialCounter\" : 0,\n  \"otpPolicyDigits\" : 6,\n  \"otpPolicyLookAheadWindow\" : 1,\n  \"otpPolicyPeriod\" : 30,\n  \"otpSupportedApplications\" : [ \"FreeOTP\", \"Google Authenticator\" ],\n  \"scopeMappings\" : [ {\n    \"clientScope\" : \"offline_access\",\n    \"roles\" : [ \"offline_access\" ]\n  } ],\n  \"clients\" : [ {\n    \"id\" : \"e55e1234-38fa-432d-8d90-39f5e024688d\",\n    \"clientId\" : \"account\",\n    \"name\" : \"${client_account}\",\n    \"baseUrl\" : \"/auth/realms/quarkus/account\",\n    \"surrogateAuthRequired\" : false,\n    \"enabled\" : true,\n    \"clientAuthenticatorType\" : \"client-secret\",\n    \"secret\" : \"0136c3ef-0dfd-4b13-a6d0-2c8b6358edec\",\n    \"defaultRoles\" : [ \"view-profile\", \"manage-account\" ],\n    \"redirectUris\" : [ \"/auth/realms/quarkus/account/*\" ],\n    \"webOrigins\" : [ ],\n    \"notBefore\" : 0,\n    \"bearerOnly\" : false,\n    \"consentRequired\" : false,\n    \"standardFlowEnabled\" : true,\n    \"implicitFlowEnabled\" : false,\n    \"directAccessGrantsEnabled\" : false,\n    \"serviceAccountsEnabled\" : false,\n    \"publicClient\" : false,\n    \"frontchannelLogout\" : false,\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : { },\n    \"authenticationFlowBindingOverrides\" : { },\n    \"fullScopeAllowed\" : false,\n    \"nodeReRegistrationTimeout\" : 0,\n    \"defaultClientScopes\" : [ \"web-origins\", \"role_list\", \"profile\", \"roles\", \"email\" ],\n    \"optionalClientScopes\" : [ \"address\", \"phone\", \"offline_access\", \"microprofile-jwt\" ]\n  }, {\n    \"id\" : \"e9cc41a2-8e35-4d5e-949e-4879880c2ddb\",\n    \"clientId\" : \"admin-cli\",\n    \"name\" : \"${client_admin-cli}\",\n    \"surrogateAuthRequired\" : false,\n    \"enabled\" : true,\n    \"clientAuthenticatorType\" : \"client-secret\",\n    \"secret\" : \"a951803a-79c7-46a6-8197-e32835286971\",\n    \"redirectUris\" : [ ],\n    \"webOrigins\" : [ ],\n    \"notBefore\" : 0,\n    \"bearerOnly\" : false,\n    \"consentRequired\" : false,\n    \"standardFlowEnabled\" : false,\n    \"implicitFlowEnabled\" : false,\n    \"directAccessGrantsEnabled\" : true,\n    \"serviceAccountsEnabled\" : false,\n    \"publicClient\" : true,\n    \"frontchannelLogout\" : false,\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : { },\n    \"authenticationFlowBindingOverrides\" : { },\n    \"fullScopeAllowed\" : false,\n    \"nodeReRegistrationTimeout\" : 0,\n    \"defaultClientScopes\" : [ \"web-origins\", \"role_list\", \"profile\", \"roles\", \"email\" ],\n    \"optionalClientScopes\" : [ \"address\", \"phone\", \"offline_access\", \"microprofile-jwt\" ]\n  }, {\n    \"id\" : \"53d4fe53-a039-471e-886a-28eddc950e95\",\n    \"clientId\" : \"broker\",\n    \"name\" : \"${client_broker}\",\n    \"surrogateAuthRequired\" : false,\n    \"enabled\" : true,\n    \"clientAuthenticatorType\" : \"client-secret\",\n    \"secret\" : \"e1f7edd7-e15c-43b4-8736-ff8204d16836\",\n    \"redirectUris\" : [ ],\n    \"webOrigins\" : [ ],\n    \"notBefore\" : 0,\n    \"bearerOnly\" : false,\n    \"consentRequired\" : false,\n    \"standardFlowEnabled\" : true,\n    \"implicitFlowEnabled\" : false,\n    \"directAccessGrantsEnabled\" : false,\n    \"serviceAccountsEnabled\" : false,\n    \"publicClient\" : false,\n    \"frontchannelLogout\" : false,\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : { },\n    \"authenticationFlowBindingOverrides\" : { },\n    \"fullScopeAllowed\" : false,\n    \"nodeReRegistrationTimeout\" : 0,\n    \"defaultClientScopes\" : [ \"web-origins\", \"role_list\", \"profile\", \"roles\", \"email\" ],\n    \"optionalClientScopes\" : [ \"address\", \"phone\", \"offline_access\", \"microprofile-jwt\" ]\n  }, {\n      \"id\": \"7f2cd8e2-dac3-41d8-b88b-bcd179f2bd39\",\n      \"clientId\": \"tackle-ui\",\n      \"surrogateAuthRequired\": false,\n      \"enabled\": true,\n      \"alwaysDisplayInConsole\": false,\n      \"clientAuthenticatorType\": \"client-secret\",\n      \"secret\": \"**********\",\n      \"redirectUris\": [\n        \"*\"\n      ],\n      \"webOrigins\": [\n        \"*\"\n      ],\n      \"notBefore\": 0,\n      \"bearerOnly\": false,\n      \"consentRequired\": false,\n      \"standardFlowEnabled\": true,\n      \"implicitFlowEnabled\": false,\n      \"directAccessGrantsEnabled\": true,\n      \"serviceAccountsEnabled\": false,\n      \"publicClient\": true,\n      \"frontchannelLogout\": false,\n      \"protocol\": \"openid-connect\",\n      \"attributes\": {\n        \"saml.assertion.signature\": \"false\",\n        \"saml.force.post.binding\": \"false\",\n        \"saml.multivalued.roles\": \"false\",\n        \"saml.encrypt\": \"false\",\n        \"backchannel.logout.revoke.offline.tokens\": \"false\",\n        \"saml.server.signature\": \"false\",\n        \"saml.server.signature.keyinfo.ext\": \"false\",\n        \"exclude.session.state.from.auth.response\": \"false\",\n        \"backchannel.logout.session.required\": \"true\",\n        \"client_credentials.use_refresh_token\": \"false\",\n        \"saml_force_name_id_format\": \"false\",\n        \"saml.client.signature\": \"false\",\n        \"tls.client.certificate.bound.access.tokens\": \"false\",\n        \"saml.authnstatement\": \"false\",\n        \"display.on.consent.screen\": \"false\",\n        \"saml.onetimeuse.condition\": \"false\"\n      },\n      \"authenticationFlowBindingOverrides\": {},\n      \"fullScopeAllowed\": true,\n      \"nodeReRegistrationTimeout\": -1,\n      \"defaultClientScopes\": [\n        \"web-origins\",\n        \"role_list\",\n        \"profile\",\n        \"roles\",\n        \"email\"\n      ],\n      \"optionalClientScopes\": [\n        \"address\",\n        \"phone\",\n        \"offline_access\",\n        \"microprofile-jwt\"\n      ]\n    }, {\n    \"id\" : \"0ac5df91-e044-4051-bd03-106a3a5fb9cc\",\n    \"clientId\" : \"backend-service\",\n    \"surrogateAuthRequired\" : false,\n    \"enabled\" : true,\n    \"clientAuthenticatorType\" : \"client-secret\",\n    \"secret\" : \"secret\",\n    \"redirectUris\" : [ ],\n    \"webOrigins\" : [ ],\n    \"notBefore\" : 0,\n    \"bearerOnly\" : false,\n    \"consentRequired\" : false,\n    \"standardFlowEnabled\" : true,\n    \"implicitFlowEnabled\" : false,\n    \"directAccessGrantsEnabled\" : true,\n    \"serviceAccountsEnabled\" : true,\n    \"authorizationServicesEnabled\" : true,\n    \"publicClient\" : false,\n    \"frontchannelLogout\" : false,\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : { },\n    \"authenticationFlowBindingOverrides\" : { },\n    \"fullScopeAllowed\" : true,\n    \"nodeReRegistrationTimeout\" : -1,\n    \"protocolMappers\" : [ {\n      \"id\" : \"3eac903f-c16b-4a78-a7e8-eb8f4d402b71\",\n      \"name\" : \"Client ID\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usersessionmodel-note-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"user.session.note\" : \"clientId\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"clientId\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"8422cefe-7f42-4f3b-abad-5f06f7d4b748\",\n      \"name\" : \"Client IP Address\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usersessionmodel-note-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"user.session.note\" : \"clientAddress\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"clientAddress\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"988e47d6-2055-45eb-82d6-0b8b25c629fc\",\n      \"name\" : \"Client Host\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usersessionmodel-note-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"user.session.note\" : \"clientHost\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"clientHost\",\n        \"jsonType.label\" : \"String\"\n      }\n    } ],\n    \"defaultClientScopes\" : [ \"web-origins\", \"role_list\", \"profile\", \"roles\", \"email\" ],\n    \"optionalClientScopes\" : [ \"address\", \"phone\", \"offline_access\", \"microprofile-jwt\" ],\n    \"authorizationSettings\" : {\n      \"allowRemoteResourceManagement\": true,\n      \"policyEnforcementMode\": \"ENFORCING\",\n      \"resources\": [\n        {\n          \"name\": \"User Resource\",\n          \"ownerManagedAccess\": false,\n          \"attributes\": {},\n          \"_id\": \"df1b74a9-3f10-499d-a581-368de48e512b\",\n          \"uris\": [\n            \"/api/users/*\"\n          ]\n        },\n        {\n          \"name\": \"Administration Resource\",\n          \"ownerManagedAccess\": false,\n          \"attributes\": {},\n          \"_id\": \"7124e2f1-e6dc-44b4-87ab-24b010090b97\",\n          \"uris\": [\n            \"/api/admin/*\"\n          ]\n        }\n      ],\n      \"policies\": [\n        {\n          \"id\": \"b8710fa6-160e-4de0-adf3-398c7007a0af\",\n          \"name\": \"Any User Policy\",\n          \"description\": \"Any user granted with the user role can access something\",\n          \"type\": \"role\",\n          \"logic\": \"POSITIVE\",\n          \"decisionStrategy\": \"UNANIMOUS\",\n          \"config\": {\n            \"roles\": \"[{\\\"id\\\":\\\"user\\\",\\\"required\\\":false}]\"\n          }\n        },\n        {\n          \"id\": \"fcef30b2-68b2-4b78-9f3d-9162c6cdf5cb\",\n          \"name\": \"Only Administrators\",\n          \"description\": \"Only administrators can access\",\n          \"type\": \"role\",\n          \"logic\": \"POSITIVE\",\n          \"decisionStrategy\": \"UNANIMOUS\",\n          \"config\": {\n            \"roles\": \"[{\\\"id\\\":\\\"admin\\\",\\\"required\\\":false}]\"\n          }\n        },\n        {\n          \"id\": \"3479dd56-02e9-4222-94fe-6a13cd065195\",\n          \"name\": \"User Resource Permission\",\n          \"type\": \"resource\",\n          \"logic\": \"POSITIVE\",\n          \"decisionStrategy\": \"UNANIMOUS\",\n          \"config\": {\n            \"resources\": \"[\\\"User Resource\\\"]\",\n            \"applyPolicies\": \"[\\\"Any User Policy\\\"]\"\n          }\n        },\n        {\n          \"id\": \"60188298-d55b-4066-b231-6a7c56ff7cc5\",\n          \"name\": \"Administration Resource Permission\",\n          \"type\": \"resource\",\n          \"logic\": \"POSITIVE\",\n          \"decisionStrategy\": \"UNANIMOUS\",\n          \"config\": {\n            \"resources\": \"[\\\"Administration Resource\\\"]\",\n            \"applyPolicies\": \"[\\\"Only Administrators\\\"]\"\n          }\n        }\n      ],\n      \"scopes\": [],\n      \"decisionStrategy\": \"UNANIMOUS\"\n    }\n  }, {\n    \"id\" : \"376bd940-e50a-4495-80fc-9c6c07312748\",\n    \"clientId\" : \"realm-management\",\n    \"name\" : \"${client_realm-management}\",\n    \"surrogateAuthRequired\" : false,\n    \"enabled\" : true,\n    \"clientAuthenticatorType\" : \"client-secret\",\n    \"secret\" : \"c41b709a-a012-4c69-89d7-4f926dba0619\",\n    \"redirectUris\" : [ ],\n    \"webOrigins\" : [ ],\n    \"notBefore\" : 0,\n    \"bearerOnly\" : true,\n    \"consentRequired\" : false,\n    \"standardFlowEnabled\" : true,\n    \"implicitFlowEnabled\" : false,\n    \"directAccessGrantsEnabled\" : false,\n    \"serviceAccountsEnabled\" : false,\n    \"publicClient\" : false,\n    \"frontchannelLogout\" : false,\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : { },\n    \"authenticationFlowBindingOverrides\" : { },\n    \"fullScopeAllowed\" : false,\n    \"nodeReRegistrationTimeout\" : 0,\n    \"defaultClientScopes\" : [ \"web-origins\", \"role_list\", \"profile\", \"roles\", \"email\" ],\n    \"optionalClientScopes\" : [ \"address\", \"phone\", \"offline_access\", \"microprofile-jwt\" ]\n  }, {\n    \"id\" : \"a8732cac-ae0f-44ec-b7f3-bd2c41eff13c\",\n    \"clientId\" : \"security-admin-console\",\n    \"name\" : \"${client_security-admin-console}\",\n    \"baseUrl\" : \"/auth/admin/quarkus/console/index.html\",\n    \"surrogateAuthRequired\" : false,\n    \"enabled\" : true,\n    \"clientAuthenticatorType\" : \"client-secret\",\n    \"secret\" : \"e571b211-2550-475d-b87f-116ff54091ee\",\n    \"redirectUris\" : [ \"/auth/admin/quarkus/console/*\" ],\n    \"webOrigins\" : [ ],\n    \"notBefore\" : 0,\n    \"bearerOnly\" : false,\n    \"consentRequired\" : false,\n    \"standardFlowEnabled\" : true,\n    \"implicitFlowEnabled\" : false,\n    \"directAccessGrantsEnabled\" : false,\n    \"serviceAccountsEnabled\" : false,\n    \"publicClient\" : true,\n    \"frontchannelLogout\" : false,\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : { },\n    \"authenticationFlowBindingOverrides\" : { },\n    \"fullScopeAllowed\" : false,\n    \"nodeReRegistrationTimeout\" : 0,\n    \"protocolMappers\" : [ {\n      \"id\" : \"280528ca-5e96-4bb9-9fc0-20311caac32d\",\n      \"name\" : \"locale\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"locale\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"locale\",\n        \"jsonType.label\" : \"String\"\n      }\n    } ],\n    \"defaultClientScopes\" : [ \"web-origins\", \"role_list\", \"profile\", \"roles\", \"email\" ],\n    \"optionalClientScopes\" : [ \"address\", \"phone\", \"offline_access\", \"microprofile-jwt\" ]\n  } ],\n  \"clientScopes\" : [ {\n    \"id\" : \"520cc3ef-2c6b-4d84-bcde-8c063241f4bd\",\n    \"name\" : \"address\",\n    \"description\" : \"OpenID Connect built-in scope: address\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"true\",\n      \"display.on.consent.screen\" : \"true\",\n      \"consent.screen.text\" : \"${addressScopeConsentText}\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"c1d3bd07-0a5f-4f4f-b381-c58a7b723029\",\n      \"name\" : \"address\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-address-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"user.attribute.formatted\" : \"formatted\",\n        \"user.attribute.country\" : \"country\",\n        \"user.attribute.postal_code\" : \"postal_code\",\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute.street\" : \"street\",\n        \"id.token.claim\" : \"true\",\n        \"user.attribute.region\" : \"region\",\n        \"access.token.claim\" : \"true\",\n        \"user.attribute.locality\" : \"locality\"\n      }\n    } ]\n  }, {\n    \"id\" : \"19920c96-a383-4f35-8ee9-27833263cf03\",\n    \"name\" : \"email\",\n    \"description\" : \"OpenID Connect built-in scope: email\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"true\",\n      \"display.on.consent.screen\" : \"true\",\n      \"consent.screen.text\" : \"${emailScopeConsentText}\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"36a0adf0-6c25-419f-98d7-cdeada8661aa\",\n      \"name\" : \"email\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-property-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"email\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"email\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"b0c39901-5e5d-4436-b685-908bb90ea1d9\",\n      \"name\" : \"email verified\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-property-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"emailVerified\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"email_verified\",\n        \"jsonType.label\" : \"boolean\"\n      }\n    } ]\n  }, {\n    \"id\" : \"55b3ee1c-cbf9-4526-93d7-aa56a9c5f1cb\",\n    \"name\" : \"microprofile-jwt\",\n    \"description\" : \"Microprofile - JWT built-in scope\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"true\",\n      \"display.on.consent.screen\" : \"false\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"59128144-a21a-4744-bb55-e66ff0503b18\",\n      \"name\" : \"upn\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-property-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"username\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"upn\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"69351a63-7d6e-45d0-be47-088c83b20fdb\",\n      \"name\" : \"groups\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-realm-role-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"multivalued\" : \"true\",\n        \"user.attribute\" : \"foo\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"groups\",\n        \"jsonType.label\" : \"String\"\n      }\n    } ]\n  }, {\n    \"id\" : \"3f190f54-8e3a-4c82-a799-bd12ddc475b2\",\n    \"name\" : \"offline_access\",\n    \"description\" : \"OpenID Connect built-in scope: offline_access\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"consent.screen.text\" : \"${offlineAccessScopeConsentText}\",\n      \"display.on.consent.screen\" : \"true\"\n    }\n  }, {\n    \"id\" : \"defa3480-5368-4f34-8075-49fb982b71b3\",\n    \"name\" : \"phone\",\n    \"description\" : \"OpenID Connect built-in scope: phone\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"true\",\n      \"display.on.consent.screen\" : \"true\",\n      \"consent.screen.text\" : \"${phoneScopeConsentText}\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"069ae414-9e98-4612-a3d6-e8b5a1fa841d\",\n      \"name\" : \"phone number verified\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"phoneNumberVerified\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"phone_number_verified\",\n        \"jsonType.label\" : \"boolean\"\n      }\n    }, {\n      \"id\" : \"cea58e24-d0e0-4cc6-9e34-7b3bf7d6d85b\",\n      \"name\" : \"phone number\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"phoneNumber\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"phone_number\",\n        \"jsonType.label\" : \"String\"\n      }\n    } ]\n  }, {\n    \"id\" : \"b7321e2e-dd8e-41cf-a527-c765155c3f78\",\n    \"name\" : \"profile\",\n    \"description\" : \"OpenID Connect built-in scope: profile\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"true\",\n      \"display.on.consent.screen\" : \"true\",\n      \"consent.screen.text\" : \"${profileScopeConsentText}\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"1d4d3df5-7af5-488e-8477-0ad7cb74d50a\",\n      \"name\" : \"nickname\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"nickname\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"nickname\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"1a5e26d6-211e-4f8a-b696-0ea9577db25a\",\n      \"name\" : \"zoneinfo\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"zoneinfo\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"zoneinfo\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"18971685-6dd7-420f-9c09-879c4f2d54d8\",\n      \"name\" : \"updated at\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"updatedAt\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"updated_at\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"b970d96b-0156-4db0-9beb-9c84c173e619\",\n      \"name\" : \"birthdate\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"birthdate\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"birthdate\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"50287033-df21-45c6-aa46-c3060e6f9855\",\n      \"name\" : \"given name\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-property-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"firstName\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"given_name\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"3dc6b97e-7063-4077-98d1-0cacf9029c7b\",\n      \"name\" : \"full name\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-full-name-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"userinfo.token.claim\" : \"true\"\n      }\n    }, {\n      \"id\" : \"3fb9391b-376c-42ef-b012-4df461c617cc\",\n      \"name\" : \"middle name\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"middleName\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"middle_name\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"83f7fc4a-5386-4f86-a103-6585e138b61d\",\n      \"name\" : \"username\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-property-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"username\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"preferred_username\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"8ef177b3-f485-44b1-afee-1901393b00c7\",\n      \"name\" : \"family name\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-property-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"lastName\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"family_name\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"e994cbc7-2a1a-4465-b7b7-12b35b4fe49e\",\n      \"name\" : \"gender\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"gender\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"gender\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"abaa4c9e-1fa2-4b45-a1bb-b3d650de9aca\",\n      \"name\" : \"picture\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"picture\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"picture\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"bf21b514-81fd-4bbe-9236-bab5fcf54561\",\n      \"name\" : \"locale\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"locale\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"locale\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"254f8de4-08e7-4d3d-a87f-4b238f0f922b\",\n      \"name\" : \"profile\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"profile\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"profile\",\n        \"jsonType.label\" : \"String\"\n      }\n    }, {\n      \"id\" : \"7934bf2a-cfc3-4b2d-a5cb-287f3ed2a977\",\n      \"name\" : \"website\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-attribute-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"userinfo.token.claim\" : \"true\",\n        \"user.attribute\" : \"website\",\n        \"id.token.claim\" : \"true\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"website\",\n        \"jsonType.label\" : \"String\"\n      }\n    } ]\n  }, {\n    \"id\" : \"f3dc793d-6011-4861-b538-399dde5434c0\",\n    \"name\" : \"role_list\",\n    \"description\" : \"SAML role list\",\n    \"protocol\" : \"saml\",\n    \"attributes\" : {\n      \"consent.screen.text\" : \"${samlRoleListScopeConsentText}\",\n      \"display.on.consent.screen\" : \"true\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"22eeabf8-a3c3-4026-a351-367f8ace7927\",\n      \"name\" : \"role list\",\n      \"protocol\" : \"saml\",\n      \"protocolMapper\" : \"saml-role-list-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"single\" : \"false\",\n        \"attribute.nameformat\" : \"Basic\",\n        \"attribute.name\" : \"Role\"\n      }\n    } ]\n  }, {\n    \"id\" : \"f72c1acd-c367-41b1-8646-b6bd5fff3e3f\",\n    \"name\" : \"roles\",\n    \"description\" : \"OpenID Connect scope for add user roles to the access token\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"false\",\n      \"display.on.consent.screen\" : \"true\",\n      \"consent.screen.text\" : \"${rolesScopeConsentText}\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"cd8e589e-5fa7-4dae-bf6e-e8f6a3fd3cff\",\n      \"name\" : \"realm roles\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-realm-role-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"user.attribute\" : \"foo\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"realm_access.roles\",\n        \"jsonType.label\" : \"String\",\n        \"multivalued\" : \"true\"\n      }\n    }, {\n      \"id\" : \"708b19d1-0709-4278-b5a1-bcbeec11f51a\",\n      \"name\" : \"audience resolve\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-audience-resolve-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : { }\n    }, {\n      \"id\" : \"25e97210-30c7-4f35-be11-407f1fa674cb\",\n      \"name\" : \"client roles\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-usermodel-client-role-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : {\n        \"user.attribute\" : \"foo\",\n        \"access.token.claim\" : \"true\",\n        \"claim.name\" : \"resource_access.${client_id}.roles\",\n        \"jsonType.label\" : \"String\",\n        \"multivalued\" : \"true\"\n      }\n    } ]\n  }, {\n    \"id\" : \"52618957-a4e8-4c6f-a902-217f2c41a2fd\",\n    \"name\" : \"web-origins\",\n    \"description\" : \"OpenID Connect scope for add allowed web origins to the access token\",\n    \"protocol\" : \"openid-connect\",\n    \"attributes\" : {\n      \"include.in.token.scope\" : \"false\",\n      \"display.on.consent.screen\" : \"false\",\n      \"consent.screen.text\" : \"\"\n    },\n    \"protocolMappers\" : [ {\n      \"id\" : \"a66ddadf-312f-491f-993c-fa58685815c6\",\n      \"name\" : \"allowed web origins\",\n      \"protocol\" : \"openid-connect\",\n      \"protocolMapper\" : \"oidc-allowed-origins-mapper\",\n      \"consentRequired\" : false,\n      \"config\" : { }\n    } ]\n  } ],\n  \"defaultDefaultClientScopes\" : [ \"role_list\", \"profile\", \"email\", \"roles\", \"web-origins\" ],\n  \"defaultOptionalClientScopes\" : [ \"offline_access\", \"address\", \"phone\", \"microprofile-jwt\" ],\n  \"browserSecurityHeaders\" : {\n    \"contentSecurityPolicyReportOnly\" : \"\",\n    \"xContentTypeOptions\" : \"nosniff\",\n    \"xRobotsTag\" : \"none\",\n    \"xFrameOptions\" : \"SAMEORIGIN\",\n    \"xXSSProtection\" : \"1; mode=block\",\n    \"contentSecurityPolicy\" : \"frame-src 'self'; frame-ancestors 'self'; object-src 'none';\",\n    \"strictTransportSecurity\" : \"max-age=31536000; includeSubDomains\"\n  },\n  \"smtpServer\" : { },\n  \"eventsEnabled\" : false,\n  \"eventsListeners\" : [ \"jboss-logging\" ],\n  \"enabledEventTypes\" : [ ],\n  \"adminEventsEnabled\" : false,\n  \"adminEventsDetailsEnabled\" : false,\n  \"components\" : {\n    \"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy\" : [ {\n      \"id\" : \"a7679218-373d-48ca-88f8-429985faeae3\",\n      \"name\" : \"Allowed Protocol Mapper Types\",\n      \"providerId\" : \"allowed-protocol-mappers\",\n      \"subType\" : \"anonymous\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"allowed-protocol-mapper-types\" : [ \"oidc-full-name-mapper\", \"saml-user-attribute-mapper\", \"saml-user-property-mapper\", \"oidc-address-mapper\", \"saml-role-list-mapper\", \"oidc-sha256-pairwise-sub-mapper\", \"oidc-usermodel-attribute-mapper\", \"oidc-usermodel-property-mapper\" ]\n      }\n    }, {\n      \"id\" : \"2ebf6f9f-4bfc-44b9-ad7c-282f2274d35b\",\n      \"name\" : \"Allowed Client Scopes\",\n      \"providerId\" : \"allowed-client-templates\",\n      \"subType\" : \"authenticated\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"allow-default-scopes\" : [ \"true\" ]\n      }\n    }, {\n      \"id\" : \"552093c3-0a0a-4234-ad7c-ae660f0f0db1\",\n      \"name\" : \"Allowed Client Scopes\",\n      \"providerId\" : \"allowed-client-templates\",\n      \"subType\" : \"anonymous\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"allow-default-scopes\" : [ \"true\" ]\n      }\n    }, {\n      \"id\" : \"8f27cf74-cee7-4a73-851f-982ee45157ca\",\n      \"name\" : \"Trusted Hosts\",\n      \"providerId\" : \"trusted-hosts\",\n      \"subType\" : \"anonymous\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"host-sending-registration-request-must-match\" : [ \"true\" ],\n        \"client-uris-must-match\" : [ \"true\" ]\n      }\n    }, {\n      \"id\" : \"ff570525-6c96-4500-9d73-c02e708b39de\",\n      \"name\" : \"Full Scope Disabled\",\n      \"providerId\" : \"scope\",\n      \"subType\" : \"anonymous\",\n      \"subComponents\" : { },\n      \"config\" : { }\n    }, {\n      \"id\" : \"b52284eb-123a-4718-aac9-857530a24a9b\",\n      \"name\" : \"Max Clients Limit\",\n      \"providerId\" : \"max-clients\",\n      \"subType\" : \"anonymous\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"max-clients\" : [ \"200\" ]\n      }\n    }, {\n      \"id\" : \"2b8c0a6d-d5c0-4ea2-8a9c-4843d3e04ec6\",\n      \"name\" : \"Consent Required\",\n      \"providerId\" : \"consent-required\",\n      \"subType\" : \"anonymous\",\n      \"subComponents\" : { },\n      \"config\" : { }\n    }, {\n      \"id\" : \"bf59de5a-2c93-43cc-a9aa-03be0129fe53\",\n      \"name\" : \"Allowed Protocol Mapper Types\",\n      \"providerId\" : \"allowed-protocol-mappers\",\n      \"subType\" : \"authenticated\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"allowed-protocol-mapper-types\" : [ \"saml-user-attribute-mapper\", \"oidc-full-name-mapper\", \"saml-role-list-mapper\", \"saml-user-property-mapper\", \"oidc-usermodel-attribute-mapper\", \"oidc-address-mapper\", \"oidc-usermodel-property-mapper\", \"oidc-sha256-pairwise-sub-mapper\" ]\n      }\n    } ],\n    \"org.keycloak.keys.KeyProvider\" : [ {\n      \"id\" : \"b3efd9cc-28b6-4404-82af-8a48a966b8ff\",\n      \"name\" : \"rsa-generated\",\n      \"providerId\" : \"rsa-generated\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"privateKey\" : [ \"MIIEowIBAAKCAQEAn5T13suF8mlS+pJXp0U1bto41nW55wpcs+Rps8ZVCRyJKWqzwSCYnI7lm0rB2wBpAAO4OPoj1zlmVoFmBPsDU9Xf7rjsJb5LIzIQDCZY44aSDZt6RR+gakPiQvlzHyW/RozYpngDJF7TsTD7rdRF1xQ4RprfBF8fwK/xsU7pxbeom5xDHZhz3fiw8s+7UdbmnazDHfAjU58aUrLGgVRfUsuoHjtsptYlOIXEifaeMetXZE+HhqLYRHQPDap5fbBJl773Trosn7N9nmzN4x1xxGj9So21WC5UboQs9sAIVgizc4omjZ5Y4RN9HLH7G4YwJctNntzmnJhDui9zAO+zSQIDAQABAoIBADi+F7rTtVoft0Cfnok8o6Y58/HVxHdxiMryUd95iy0FN4RBi48FTx6D9QKFz25Ws/8sU2n3D51srIXf1u24b1N0/f39RQKaqk7mcyxOylaEuBQcj5pah4ihgKd92UBfBKdKV5LBo6RgD3e2yhbiHr8+UlBQqzH7vOef6Bm6zIbfmi3N88swAJhP0YizRZFklsbmLsK6nkwyro00CHJvPVKSBbM+ad+/zIBsLw56MvNngB5TuFguUgoljd6M1T2z4utmZGlTUqrfE1onAVLJZoGnRohyIr7dJEg6YxWR70PxsgmkDKyeRvet9P1trO0n+OSprusfrC3cHJStabap1V0CgYEA1A/CtsqTnjdYYsB19eumZgdpzUgNc/YEAzZ/OWb8yTLoB2ncci+63A1rXHUXAqJFY7vtjn5mxv7SuASNbUrzq+6KfZvC1x9XEtnczqT/ypunNfxmIZuj8Nuu6vtURguZ8kPPwdkI8toTizRFeRE5ZDBvoQryiEVYugfHaHT5vzsCgYEAwKWODwquI0Lv9BuwdNVrBXQpkKh3ZfYOA7i9xvhxlM7xUu8OMCwwCPn3r7vrW5APjTqX4h330mJ44SLEs+7gbCUs4BbJBLA6g0ChlHa9PTkxp6tk2nDF/B34fxiZSRkE85L+d+at0Dc3hnlzLCJCzJawGpoPniPU9e4w0p4dN0sCgYAsGnMGjS8SUrRhJWHjGXVr9tK8TOXvXhULjgP7rj2Yoqu7Dvs4DFEyft/7RKbad2EzEtyfLA64CDtO5jN7rYDsGxpWcVSeZPg5BXJ0z8AbJTArfCjJiJMZ/rZsTIUEZFlKF2xYBolj6JLz+pUQTtK+0YwF1D8ItFN1rTR9twZSDQKBgQC6sPXNX+VH6LuPTjIf1x8CxwLs3EXxOpV0R9kp9GRl+HJnk6GlT30xhcThufQo5KAdllXQXIhoiuNoEoCbevhj9Vbax1oBQCNERSMRNEzKAx46xd9TzYwgeo7x5E3QR/3DaoVOfu+cY5ZcrF/PulgP2kxJS1mtQD5GIpGP2oinpwKBgGqiqTFPqRcelx76vBvTU+Jp1zM62T4AotbMrSQR/oUvqHe5Ytj/SbZx+wbbHAiyGgV700Mosyviik83YEAbR3kdOPjgYvAJJW2Y3jEMdQ7MwriXz8XLh5BGmYfVjkSOJXed9ua9WlYLKOJeXXv191BbDvrx5NXuJyVVU4vJx3YZ\" ],\n        \"certificate\" : [ \"MIICnTCCAYUCBgFp4EYIrjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdwcm90ZWFuMB4XDTE5MDQwMjIyNTYxOVoXDTI5MDQwMjIyNTc1OVowEjEQMA4GA1UEAwwHcHJvdGVhbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ+U9d7LhfJpUvqSV6dFNW7aONZ1uecKXLPkabPGVQkciSlqs8EgmJyO5ZtKwdsAaQADuDj6I9c5ZlaBZgT7A1PV3+647CW+SyMyEAwmWOOGkg2bekUfoGpD4kL5cx8lv0aM2KZ4AyRe07Ew+63URdcUOEaa3wRfH8Cv8bFO6cW3qJucQx2Yc934sPLPu1HW5p2swx3wI1OfGlKyxoFUX1LLqB47bKbWJTiFxIn2njHrV2RPh4ai2ER0Dw2qeX2wSZe+9066LJ+zfZ5szeMdccRo/UqNtVguVG6ELPbACFYIs3OKJo2eWOETfRyx+xuGMCXLTZ7c5pyYQ7ovcwDvs0kCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVtmRKDb4OK5iSA46tagMBkp6L7WuPpCWuHGWwobEP+BecYsShW7zP3s12oA8SNSwbhvu0CRqgzxhuypgf3hKQFVU153Erv4hzkj+8S0s5LR/ZE7tDNY2lzJ3yQKXy3Md7EkuzzvOZ50MTrcSKAanWq/ZW1OTnrtGymj5zGJnTg7mMnJzEIGePxkvPu/QdchiPBLqxfZYm1jsFGY25djOC3N/KmVcRVmPRGuu6D8tBFHlKoPfZYPdbMvsvs24aupHKRcZ+ofTCpK+2Qo8c0pSSqeEYHGmuGqC6lC6ozxtxSABPO9Q1R1tZBU7Kg5HvXUwwmoVS3EGub46YbHqbmWMLg==\" ],\n        \"priority\" : [ \"100\" ]\n      }\n    }, {\n      \"id\" : \"20460ca5-ec24-4a9b-839a-457743d3f841\",\n      \"name\" : \"hmac-generated\",\n      \"providerId\" : \"hmac-generated\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"kid\" : [ \"96afd00e-85cf-4d35-b18e-061d3813d8b2\" ],\n        \"secret\" : [ \"qBFGKdUGf6xDgKphnRfoFzIzaFHJW4bYnZ9MinPFzN38X5_ctq-2u1q5RdZzeJukXvk2biHB8_s3DxWmmLZFsA\" ],\n        \"priority\" : [ \"100\" ],\n        \"algorithm\" : [ \"HS256\" ]\n      }\n    }, {\n      \"id\" : \"4f02d984-7a23-4ce1-8591-848a71390efe\",\n      \"name\" : \"aes-generated\",\n      \"providerId\" : \"aes-generated\",\n      \"subComponents\" : { },\n      \"config\" : {\n        \"kid\" : [ \"b04473d3-8395-4016-b455-19a9e951106b\" ],\n        \"secret\" : [ \"x68mMOVdz3qKWzltzReV0g\" ],\n        \"priority\" : [ \"100\" ]\n      }\n    } ]\n  },\n  \"internationalizationEnabled\" : false,\n  \"supportedLocales\" : [ ],\n  \"authenticationFlows\" : [ {\n    \"id\" : \"d6c3e282-a738-4b8b-98c2-378b9faf8344\",\n    \"alias\" : \"Handle Existing Account\",\n    \"description\" : \"Handle what to do if there is existing account with same email/username like authenticated identity provider\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : false,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"idp-confirm-link\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"idp-email-verification\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 30,\n      \"flowAlias\" : \"Verify Existing Account by Re-authentication\",\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : true\n    } ]\n  }, {\n    \"id\" : \"4855860b-4009-4f1b-ba6b-60581618ea62\",\n    \"alias\" : \"Verify Existing Account by Re-authentication\",\n    \"description\" : \"Reauthentication of existing account\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : false,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"idp-username-password-form\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"auth-otp-form\",\n      \"requirement\" : \"OPTIONAL\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"8a9872b0-65f1-47ff-9565-fa826ac64cd4\",\n    \"alias\" : \"browser\",\n    \"description\" : \"browser based authentication\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"auth-cookie\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"auth-spnego\",\n      \"requirement\" : \"DISABLED\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"identity-provider-redirector\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 25,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 30,\n      \"flowAlias\" : \"forms\",\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : true\n    } ]\n  }, {\n    \"id\" : \"51b8ed14-62b6-49b3-b602-0b51508349e0\",\n    \"alias\" : \"clients\",\n    \"description\" : \"Base authentication for clients\",\n    \"providerId\" : \"client-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"client-secret\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"client-jwt\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"client-secret-jwt\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 30,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"client-x509\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 40,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"9b65133a-ee71-494a-a659-6804513fc30b\",\n    \"alias\" : \"direct grant\",\n    \"description\" : \"OpenID Connect Resource Owner Grant\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"direct-grant-validate-username\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"direct-grant-validate-password\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"direct-grant-validate-otp\",\n      \"requirement\" : \"OPTIONAL\",\n      \"priority\" : 30,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"f62bc4ad-25ac-4f83-963b-32820af3a683\",\n    \"alias\" : \"docker auth\",\n    \"description\" : \"Used by Docker clients to authenticate against the IDP\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"docker-http-basic-authenticator\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"1b423fe7-f312-404c-903b-f1260a77259b\",\n    \"alias\" : \"first broker login\",\n    \"description\" : \"Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticatorConfig\" : \"review profile config\",\n      \"authenticator\" : \"idp-review-profile\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticatorConfig\" : \"create unique user config\",\n      \"authenticator\" : \"idp-create-user-if-unique\",\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"requirement\" : \"ALTERNATIVE\",\n      \"priority\" : 30,\n      \"flowAlias\" : \"Handle Existing Account\",\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : true\n    } ]\n  }, {\n    \"id\" : \"9c9530b3-e3c6-481b-99e8-1461a9752e8e\",\n    \"alias\" : \"forms\",\n    \"description\" : \"Username, password, otp and other auth forms.\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : false,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"auth-username-password-form\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"auth-otp-form\",\n      \"requirement\" : \"OPTIONAL\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"70fb94ac-354c-4629-a5fe-5135d0137964\",\n    \"alias\" : \"http challenge\",\n    \"description\" : \"An authentication flow based on challenge-response HTTP Authentication Schemes\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"no-cookie-redirect\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"basic-auth\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"basic-auth-otp\",\n      \"requirement\" : \"DISABLED\",\n      \"priority\" : 30,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"auth-spnego\",\n      \"requirement\" : \"DISABLED\",\n      \"priority\" : 40,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"08292a4a-6722-4e33-a5d9-354c2628f567\",\n    \"alias\" : \"registration\",\n    \"description\" : \"registration flow\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"registration-page-form\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"flowAlias\" : \"registration form\",\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : true\n    } ]\n  }, {\n    \"id\" : \"668dc4b6-fe1a-4d24-ab5b-bc76e20ac390\",\n    \"alias\" : \"registration form\",\n    \"description\" : \"registration form\",\n    \"providerId\" : \"form-flow\",\n    \"topLevel\" : false,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"registration-user-creation\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"registration-profile-action\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 40,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"registration-password-action\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 50,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"registration-recaptcha-action\",\n      \"requirement\" : \"DISABLED\",\n      \"priority\" : 60,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"a0e191f0-ce9a-4a75-b6e4-97332b05f7e5\",\n    \"alias\" : \"reset credentials\",\n    \"description\" : \"Reset credentials for a user if they forgot their password or something\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"reset-credentials-choose-user\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"reset-credential-email\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 20,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"reset-password\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 30,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    }, {\n      \"authenticator\" : \"reset-otp\",\n      \"requirement\" : \"OPTIONAL\",\n      \"priority\" : 40,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  }, {\n    \"id\" : \"ad4beb21-8e9a-4fca-af41-0f757169f26c\",\n    \"alias\" : \"saml ecp\",\n    \"description\" : \"SAML ECP Profile Authentication Flow\",\n    \"providerId\" : \"basic-flow\",\n    \"topLevel\" : true,\n    \"builtIn\" : true,\n    \"authenticationExecutions\" : [ {\n      \"authenticator\" : \"http-basic-authenticator\",\n      \"requirement\" : \"REQUIRED\",\n      \"priority\" : 10,\n      \"userSetupAllowed\" : false,\n      \"autheticatorFlow\" : false\n    } ]\n  } ],\n  \"authenticatorConfig\" : [ {\n    \"id\" : \"25632f91-6071-423a-8e9c-7322cdc1b011\",\n    \"alias\" : \"create unique user config\",\n    \"config\" : {\n      \"require.password.update.after.registration\" : \"false\"\n    }\n  }, {\n    \"id\" : \"02d7f70b-1ebc-4e72-a65c-d94a600895ac\",\n    \"alias\" : \"review profile config\",\n    \"config\" : {\n      \"update.profile.on.first.login\" : \"missing\"\n    }\n  } ],\n  \"requiredActions\" : [ {\n    \"alias\" : \"CONFIGURE_TOTP\",\n    \"name\" : \"Configure OTP\",\n    \"providerId\" : \"CONFIGURE_TOTP\",\n    \"enabled\" : true,\n    \"defaultAction\" : false,\n    \"priority\" : 10,\n    \"config\" : { }\n  }, {\n    \"alias\" : \"terms_and_conditions\",\n    \"name\" : \"Terms and Conditions\",\n    \"providerId\" : \"terms_and_conditions\",\n    \"enabled\" : false,\n    \"defaultAction\" : false,\n    \"priority\" : 20,\n    \"config\" : { }\n  }, {\n    \"alias\" : \"UPDATE_PASSWORD\",\n    \"name\" : \"Update Password\",\n    \"providerId\" : \"UPDATE_PASSWORD\",\n    \"enabled\" : true,\n    \"defaultAction\" : false,\n    \"priority\" : 30,\n    \"config\" : { }\n  }, {\n    \"alias\" : \"UPDATE_PROFILE\",\n    \"name\" : \"Update Profile\",\n    \"providerId\" : \"UPDATE_PROFILE\",\n    \"enabled\" : true,\n    \"defaultAction\" : false,\n    \"priority\" : 40,\n    \"config\" : { }\n  }, {\n    \"alias\" : \"VERIFY_EMAIL\",\n    \"name\" : \"Verify Email\",\n    \"providerId\" : \"VERIFY_EMAIL\",\n    \"enabled\" : true,\n    \"defaultAction\" : false,\n    \"priority\" : 50,\n    \"config\" : { }\n  } ],\n  \"browserFlow\" : \"browser\",\n  \"registrationFlow\" : \"registration\",\n  \"directGrantFlow\" : \"direct grant\",\n  \"resetCredentialsFlow\" : \"reset credentials\",\n  \"clientAuthenticationFlow\" : \"clients\",\n  \"dockerAuthenticationFlow\" : \"docker auth\",\n  \"attributes\" : {\n    \"_browser_header.xXSSProtection\" : \"1; mode=block\",\n    \"_browser_header.xFrameOptions\" : \"SAMEORIGIN\",\n    \"_browser_header.strictTransportSecurity\" : \"max-age=31536000; includeSubDomains\",\n    \"permanentLockout\" : \"false\",\n    \"quickLoginCheckMilliSeconds\" : \"1000\",\n    \"_browser_header.xRobotsTag\" : \"none\",\n    \"maxFailureWaitSeconds\" : \"900\",\n    \"minimumQuickLoginWaitSeconds\" : \"60\",\n    \"failureFactor\" : \"30\",\n    \"actionTokenGeneratedByUserLifespan\" : \"300\",\n    \"maxDeltaTimeSeconds\" : \"43200\",\n    \"_browser_header.xContentTypeOptions\" : \"nosniff\",\n    \"offlineSessionMaxLifespan\" : \"5184000\",\n    \"actionTokenGeneratedByAdminLifespan\" : \"43200\",\n    \"_browser_header.contentSecurityPolicyReportOnly\" : \"\",\n    \"bruteForceProtected\" : \"false\",\n    \"_browser_header.contentSecurityPolicy\" : \"frame-src 'self'; frame-ancestors 'self'; object-src 'none';\",\n    \"waitIncrementSeconds\" : \"60\",\n    \"offlineSessionMaxLifespanEnabled\" : \"false\"\n  },\n  \"users\" : [ {\n    \"id\" : \"af134cab-f41c-4675-b141-205f975db679\",\n    \"username\" : \"admin\",\n    \"enabled\" : true,\n    \"totp\" : false,\n    \"emailVerified\" : false,\n    \"credentials\" : [ {\n      \"type\" : \"password\",\n      \"hashedSaltedValue\" : \"NICTtwsvSxJ5hL8hLAuleDUv9jwZcuXgxviMXvR++cciyPtiIEStEaJUyfA9DOir59awjPrHOumsclPVjNBplA==\",\n      \"salt\" : \"T/2P5o5oxFJUEk68BRURRg==\",\n      \"hashIterations\" : 27500,\n      \"counter\" : 0,\n      \"algorithm\" : \"pbkdf2-sha256\",\n      \"digits\" : 0,\n      \"period\" : 0,\n      \"createdDate\" : 1554245879354,\n      \"config\" : { }\n    } ],\n    \"disableableCredentialTypes\" : [ \"password\" ],\n    \"requiredActions\" : [ ],\n    \"realmRoles\" : [ \"admin\", \"user\" ],\n    \"notBefore\" : 0,\n    \"groups\" : [ ]\n  }, {\n    \"id\" : \"eb4123a3-b722-4798-9af5-8957f823657a\",\n    \"username\" : \"alice\",\n    \"enabled\" : true,\n    \"totp\" : false,\n    \"emailVerified\" : false,\n    \"credentials\" : [ {\n      \"type\" : \"password\",\n      \"hashedSaltedValue\" : \"A3okqV2T/ybXTVEgKfosoSjP8Yc9IZbFP/SY4cEd6hag7TABQrQ6nUSuwagGt96l8cw1DTijO75PqX6uiTXMzw==\",\n      \"salt\" : \"sl4mXx6T9FypPH/s9TngfQ==\",\n      \"hashIterations\" : 27500,\n      \"counter\" : 0,\n      \"algorithm\" : \"pbkdf2-sha256\",\n      \"digits\" : 0,\n      \"period\" : 0,\n      \"createdDate\" : 1554245879116,\n      \"config\" : { }\n    } ],\n    \"disableableCredentialTypes\" : [ \"password\" ],\n    \"requiredActions\" : [ ],\n    \"realmRoles\" : [ \"user\" ],\n    \"notBefore\" : 0,\n    \"groups\" : [ ]\n  }, {\n    \"id\" : \"1eed6a8e-a853-4597-b4c6-c4c2533546a0\",\n    \"username\" : \"jdoe\",\n    \"enabled\" : true,\n    \"totp\" : false,\n    \"emailVerified\" : false,\n    \"credentials\" : [ {\n      \"type\" : \"password\",\n      \"hashedSaltedValue\" : \"JV3DUNLjqOadjbBOtC4rvacQI553CGaDGAzBS8MR5ReCr7SwF3E6CsW3T7/XO8ITZAsch8+A/6loeuCoVLLJrg==\",\n      \"salt\" : \"uCbOH7HZtyDtMd0E9DG/nw==\",\n      \"hashIterations\" : 27500,\n      \"counter\" : 0,\n      \"algorithm\" : \"pbkdf2-sha256\",\n      \"digits\" : 0,\n      \"period\" : 0,\n      \"createdDate\" : 1554245879227,\n      \"config\" : { }\n    } ],\n    \"disableableCredentialTypes\" : [ \"password\" ],\n    \"requiredActions\" : [ ],\n    \"realmRoles\" : [ \"confidential\", \"user\" ],\n    \"notBefore\" : 0,\n    \"groups\" : [ ]\n  }, {\n    \"id\" : \"948c59ec-46ed-4d99-aa43-02900029b930\",\n    \"createdTimestamp\" : 1554245880023,\n    \"username\" : \"service-account-backend-service\",\n    \"enabled\" : true,\n    \"totp\" : false,\n    \"emailVerified\" : false,\n    \"email\" : \"service-account-backend-service@placeholder.org\",\n    \"serviceAccountClientId\" : \"backend-service\",\n    \"credentials\" : [ ],\n    \"disableableCredentialTypes\" : [ ],\n    \"requiredActions\" : [ ],\n    \"realmRoles\" : [ \"offline_access\" ],\n    \"clientRoles\" : {\n      \"backend-service\" : [ \"uma_protection\" ],\n      \"account\" : [ \"view-profile\", \"manage-account\" ]\n    },\n    \"notBefore\" : 0,\n    \"groups\" : [ ]\n  } ],\n  \"keycloakVersion\" : \"6.0.0\",\n  \"userManagedAccessAllowed\" : false\n}\n"
+      },
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "keycloak-realm",
+        "labels": {
+          "app.kubernetes.io/name": "keycloak",
+          "app.kubernetes.io/component": "sso",
+          "app.kubernetes.io/instance": "keycloak",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "controls-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "controls-postgres",
+          "app.kubernetes.io/version": "10.6",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "controls-postgres",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "tcp",
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 5432
+          }
+        ],
+        "selector": {
+          "app.kubernetes.io/name": "controls-postgres",
+          "app.kubernetes.io/version": "10.6"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "application-inventory-postgresql",
+        "labels": {
+          "app.kubernetes.io/name": "application-inventory-postgres",
+          "app.kubernetes.io/version": "10.6",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "application-inventory-postgres",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "tcp",
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 5432
+          }
+        ],
+        "selector": {
+          "app.kubernetes.io/name": "application-inventory-postgres",
+          "app.kubernetes.io/version": "10.6"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "controls-postgres",
+        "labels": {
+          "app.kubernetes.io/name": "controls-postgres",
+          "app.kubernetes.io/version": "10.6",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "controls-postgres",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app.kubernetes.io/name": "controls-postgres",
+            "app.kubernetes.io/version": "10.6"
+          }
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "controls-postgres",
+              "app.kubernetes.io/version": "10.6"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "controls-postgresql-data",
+                "persistentVolumeClaim": {
+                  "claimName": "controls-postgresql"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "postgres",
+                "image": "postgres:10.6",
+                "ports": [
+                  {
+                    "containerPort": 5432,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "POSTGRES_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "controls-postgresql",
+                        "key": "database-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "controls-postgresql",
+                        "key": "database-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_DB",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "controls-postgresql",
+                        "key": "database-name"
+                      }
+                    }
+                  }
+                ],
+                "resources": {},
+                "livenessProbe": {
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'\n"
+                    ]
+                  },
+                  "initialDelaySeconds": 60,
+                  "timeoutSeconds": 10,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "readinessProbe": {
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'\n"
+                    ]
+                  },
+                  "initialDelaySeconds": 10,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "IfNotPresent",
+                "volumeMounts": [
+                  {
+                    "name": "controls-postgresql-data",
+                    "mountPath": "/var/lib/postgresql"
+                  }
+                ],
+                "securityContext": {
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "securityContext": {},
+            "schedulerName": "default-scheduler"
+          }
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": "25%",
+            "maxSurge": "25%"
+          }
+        },
+        "revisionHistoryLimit": 10,
+        "progressDeadlineSeconds": 600
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "application-inventory-postgres",
+        "labels": {
+          "app.kubernetes.io/name": "application-inventory-postgres",
+          "app.kubernetes.io/version": "10.6",
+          "app.kubernetes.io/component": "database",
+          "app.kubernetes.io/instance": "application-inventory-postgres",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app.kubernetes.io/name": "application-inventory-postgres",
+            "app.kubernetes.io/version": "10.6"
+          }
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "application-inventory-postgres",
+              "app.kubernetes.io/version": "10.6"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "application-inventory-postgresql-data",
+                "persistentVolumeClaim": {
+                  "claimName": "application-inventory-postgresql"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "postgres",
+                "image": "postgres:10.6",
+                "ports": [
+                  {
+                    "containerPort": 5432,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "POSTGRES_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "application-inventory-postgresql",
+                        "key": "database-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "application-inventory-postgresql",
+                        "key": "database-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_DB",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "application-inventory-postgresql",
+                        "key": "database-name"
+                      }
+                    }
+                  }
+                ],
+                "resources": {},
+                "livenessProbe": {
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'\n"
+                    ]
+                  },
+                  "initialDelaySeconds": 60,
+                  "timeoutSeconds": 10,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "readinessProbe": {
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'\n"
+                    ]
+                  },
+                  "initialDelaySeconds": 10,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "IfNotPresent",
+                "volumeMounts": [
+                  {
+                    "name": "application-inventory-postgresql-data",
+                    "mountPath": "/var/lib/postgresql"
+                  }
+                ],
+                "securityContext": {
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "securityContext": {},
+            "schedulerName": "default-scheduler"
+          }
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": "25%",
+            "maxSurge": "25%"
+          }
+        },
+        "revisionHistoryLimit": 10,
+        "progressDeadlineSeconds": 600
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "tackle-ui",
+        "labels": {
+          "app.kubernetes.io/name": "tackle-ui",
+          "app.kubernetes.io/component": "ui",
+          "app.kubernetes.io/instance": "tackle-ui",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app.kubernetes.io/name": "tackle-ui",
+            "app.kubernetes.io/instance": "tackle-ui",
+            "app.kubernetes.io/part-of": "tackle"
+          }
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "tackle-ui",
+              "app.kubernetes.io/instance": "tackle-ui",
+              "app.kubernetes.io/part-of": "tackle"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "tackle-ui",
+                "image": "${CONTROLS_UI_CONTAINER_IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  },
+                  {
+                    "containerPort": 8443,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "CONTROLS_API_URL",
+                    "value": "http://tackle-controls:8080"
+                  },
+                  {
+                    "name": "APPLICATION_INVENTORY_API_URL",
+                    "value": "http://tackle-application-inventory:8080"
+                  },
+                  {
+                    "name": "SSO_REALM",
+                    "value": "quarkus"
+                  },
+                  {
+                    "name": "SSO_CLIENT_ID",
+                    "value": "tackle-ui"
+                  },
+                  {
+                    "name": "SSO_SERVER_URL",
+                    "value": "http://keycloak:8080"
+                  }
+                ],
+                "readinessProbe": {
+                  "initialDelaySeconds": 10,
+                  "httpGet": {
+                    "path": "/",
+                    "scheme": "HTTP",
+                    "port": 8080
+                  },
+                  "periodSeconds": 5
+                },
+                "livenessProbe": {
+                  "initialDelaySeconds": 10,
+                  "exec": {
+                    "command": [
+                      "/bin/sh",
+                      "-c",
+                      "[ -f /run/nginx.pid ] && ps -A | grep nginx"
+                    ]
+                  },
+                  "periodSeconds": 5
+                },
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "Always"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "securityContext": {},
+            "schedulerName": "default-scheduler"
+          }
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": "25%",
+            "maxSurge": "25%"
+          }
+        },
+        "revisionHistoryLimit": 10,
+        "progressDeadlineSeconds": 600
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "tackle-ui",
+        "labels": {
+          "app.kubernetes.io/name": "tackle-ui",
+          "app.kubernetes.io/component": "ui",
+          "app.kubernetes.io/instance": "tackle-ui",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "8080-tcp",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app.kubernetes.io/name": "tackle-ui"
+        }
+      }
+    },
+    {
+      "apiVersion" : "v1",
+      "kind" : "Service",
+      "metadata" : {
+        "annotations" : {
+          "prometheus.io/scheme" : "http",
+          "prometheus.io/scrape" : "true",
+          "prometheus.io/path" : "/q/metrics",
+          "prometheus.io/port" : "8080"
+        },
+        "labels" : {
+          "app.kubernetes.io/name" : "tackle-controls",
+          "app.kubernetes.io/part-of" : "tackle",
+          "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+          "app.kubernetes.io/component" : "rest",
+          "app.openshift.io/runtime" : "quarkus"
+        },
+        "name" : "tackle-controls"
+      },
+      "spec" : {
+        "ports" : [ {
+          "name" : "http",
+          "port" : 8080,
+          "targetPort" : 8080
+        } ],
+        "selector" : {
+          "app.kubernetes.io/name" : "tackle-controls",
+          "app.kubernetes.io/part-of" : "tackle",
+          "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native"
+        },
+        "type" : "ClusterIP"
+      }
+    },
+    {
+      "apiVersion" : "v1",
+      "kind" : "Service",
+      "metadata" : {
+        "annotations" : {
+          "prometheus.io/scheme" : "http",
+          "prometheus.io/scrape" : "true",
+          "prometheus.io/path" : "/q/metrics",
+          "prometheus.io/port" : "8080"
+        },
+        "labels" : {
+          "app.kubernetes.io/name" : "tackle-application-inventory",
+          "app.kubernetes.io/part-of" : "tackle",
+          "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+          "app.kubernetes.io/component" : "rest",
+          "app.openshift.io/runtime" : "quarkus"
+        },
+        "name" : "tackle-application-inventory"
+      },
+      "spec" : {
+        "ports" : [ {
+          "name" : "http",
+          "port" : 8080,
+          "targetPort" : 8080
+        } ],
+        "selector" : {
+          "app.kubernetes.io/name" : "tackle-application-inventory",
+          "app.kubernetes.io/part-of" : "tackle",
+          "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native"
+        },
+        "type" : "ClusterIP"
+      }
+    },
+    {
+      "apiVersion" : "apps/v1",
+      "kind" : "Deployment",
+      "metadata" : {
+        "annotations" : {
+          "prometheus.io/port" : "8080",
+          "prometheus.io/scheme" : "http",
+          "prometheus.io/scrape" : "true",
+          "prometheus.io/path" : "/q/metrics"
+        },
+        "labels" : {
+          "app.kubernetes.io/component" : "rest",
+          "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+          "app.kubernetes.io/name" : "tackle-controls",
+          "app.kubernetes.io/part-of" : "tackle"
+        },
+        "name" : "tackle-controls"
+      },
+      "spec" : {
+        "replicas" : 1,
+        "selector" : {
+          "matchLabels" : {
+            "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+            "app.kubernetes.io/name" : "tackle-controls",
+            "app.kubernetes.io/part-of" : "tackle"
+          }
+        },
+        "template" : {
+          "metadata" : {
+            "annotations" : {
+              "prometheus.io/port" : "8080",
+              "prometheus.io/scheme" : "http",
+              "prometheus.io/scrape" : "true",
+              "prometheus.io/path" : "/q/metrics"
+            },
+            "labels" : {
+              "app.kubernetes.io/component" : "rest",
+              "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+              "app.kubernetes.io/name" : "tackle-controls",
+              "app.kubernetes.io/part-of" : "tackle"
+            }
+          },
+          "spec" : {
+            "containers" : [ {
+              "env" : [ {
+                "name" : "KUBERNETES_NAMESPACE",
+                "valueFrom" : {
+                  "fieldRef" : {
+                    "fieldPath" : "metadata.namespace"
+                  }
+                }
+              }, {
+                "name" : "QUARKUS_DATASOURCE_USERNAME",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "controls-postgresql",
+                    "key": "database-user"
+                  }
+                }
+              }, {
+                "name" : "QUARKUS_DATASOURCE_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "controls-postgresql",
+                    "key": "database-password"
+                  }
+                }
+              } ],
+              "image" : "${CONTROLS_REST_CONTAINER_IMAGE}",
+              "imagePullPolicy" : "Always",
+              "livenessProbe" : {
+                "failureThreshold" : 3,
+                "httpGet" : {
+                  "path" : "/controls/q/health/live",
+                  "port" : 8080,
+                  "scheme" : "HTTP"
+                },
+                "initialDelaySeconds" : 0,
+                "periodSeconds" : 30,
+                "successThreshold" : 1,
+                "timeoutSeconds" : 10
+              },
+              "name" : "tackle-controls",
+              "ports" : [ {
+                "containerPort" : 8080,
+                "name" : "http",
+                "protocol" : "TCP"
+              } ],
+              "readinessProbe" : {
+                "failureThreshold" : 3,
+                "httpGet" : {
+                  "path" : "/controls/q/health/ready",
+                  "port" : 8080,
+                  "scheme" : "HTTP"
+                },
+                "initialDelaySeconds" : 0,
+                "periodSeconds" : 30,
+                "successThreshold" : 1,
+                "timeoutSeconds" : 10
+              }
+            } ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion" : "apps/v1",
+      "kind" : "Deployment",
+      "metadata" : {
+        "annotations" : {
+          "prometheus.io/port" : "8080",
+          "prometheus.io/scheme" : "http",
+          "prometheus.io/scrape" : "true",
+          "prometheus.io/path" : "/q/metrics"
+        },
+        "labels" : {
+          "app.kubernetes.io/component" : "rest",
+          "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+          "app.kubernetes.io/name" : "tackle-application-inventory",
+          "app.kubernetes.io/part-of" : "tackle"
+        },
+        "name" : "tackle-application-inventory"
+      },
+      "spec" : {
+        "replicas" : 1,
+        "selector" : {
+          "matchLabels" : {
+            "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+            "app.kubernetes.io/name" : "tackle-application-inventory",
+            "app.kubernetes.io/part-of" : "tackle"
+          }
+        },
+        "template" : {
+          "metadata" : {
+            "annotations" : {
+              "prometheus.io/port" : "8080",
+              "prometheus.io/scheme" : "http",
+              "prometheus.io/scrape" : "true",
+              "prometheus.io/path" : "/q/metrics"
+            },
+            "labels" : {
+              "app.kubernetes.io/component" : "rest",
+              "app.kubernetes.io/version" : "0.0.1-SNAPSHOT-native",
+              "app.kubernetes.io/name" : "tackle-application-inventory",
+              "app.kubernetes.io/part-of" : "tackle"
+            }
+          },
+          "spec" : {
+            "containers" : [ {
+              "env" : [ {
+                "name" : "KUBERNETES_NAMESPACE",
+                "valueFrom" : {
+                  "fieldRef" : {
+                    "fieldPath" : "metadata.namespace"
+                  }
+                }
+              }, {
+                "name" : "QUARKUS_DATASOURCE_USERNAME",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "application-inventory-postgresql",
+                    "key": "database-user"
+                  }
+                }
+              }, {
+                "name" : "QUARKUS_DATASOURCE_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "application-inventory-postgresql",
+                    "key": "database-password"
+                  }
+                }
+              } ],
+              "image" : "${APPLICATION_INVENTORY_REST_CONTAINER_IMAGE}",
+              "imagePullPolicy" : "Always",
+              "livenessProbe" : {
+                "failureThreshold" : 3,
+                "httpGet" : {
+                  "path" : "/application-inventory/q/health/live",
+                  "port" : 8080,
+                  "scheme" : "HTTP"
+                },
+                "initialDelaySeconds" : 0,
+                "periodSeconds" : 30,
+                "successThreshold" : 1,
+                "timeoutSeconds" : 10
+              },
+              "name" : "tackle-application-inventory",
+              "ports" : [ {
+                "containerPort" : 8080,
+                "name" : "http",
+                "protocol" : "TCP"
+              } ],
+              "readinessProbe" : {
+                "failureThreshold" : 3,
+                "httpGet" : {
+                  "path" : "/application-inventory/q/health/ready",
+                  "port" : 8080,
+                  "scheme" : "HTTP"
+                },
+                "initialDelaySeconds" : 0,
+                "periodSeconds" : 30,
+                "successThreshold" : 1,
+                "timeoutSeconds" : 10
+              }
+            } ]
+          }
+        }
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "route.openshift.io/v1",
+      "metadata": {
+        "name": "tackle",
+        "labels": {
+          "app.kubernetes.io/component": "network",
+          "app.kubernetes.io/instance": "tackle",
+          "app.kubernetes.io/name": "tackle",
+          "app.kubernetes.io/part-of": "tackle"
+        }
+      },
+      "spec": {
+        "to": {
+          "kind": "Service",
+          "name": "tackle-ui",
+          "weight": 100
+        },
+        "port": {
+          "targetPort": "8080-tcp"
+        },
+        "tls": {
+          "termination": "edge",
+          "insecureEdgeTerminationPolicy": "Redirect"
+        },
+        "wildcardPolicy": "None"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Moving the K8s and OCP templates to this repository. The content of the files are exactly the same.
 
- Files were taken from: https://github.com/konveyor/tackle-controls/tree/main/src/main/kubernetes
- Skipped files `kubertete.json`, `minikub.json`, `minikub0.json`, `minikube-standalone` since I consider either they are not necessary.