### PR TITLE
Reduce access token lifespan

### DIFF
--- a/kubernetes/kubernetes-tackle.yaml
+++ b/kubernetes/kubernetes-tackle.yaml
@@ -360,7 +360,7 @@ data:
       "notBefore" : 0,
       "revokeRefreshToken" : false,
       "refreshTokenMaxReuse" : 0,
-      "accessTokenLifespan" : 300,
+      "accessTokenLifespan" : 60,
       "accessTokenLifespanForImplicitFlow" : 900,
       "ssoSessionIdleTimeout" : 1800,
       "ssoSessionMaxLifespan" : 36000,

--- a/kubernetes/openshift-tackle.yaml
+++ b/kubernetes/openshift-tackle.yaml
@@ -432,7 +432,7 @@ objects:
           "notBefore" : 0,
           "revokeRefreshToken" : false,
           "refreshTokenMaxReuse" : 0,
-          "accessTokenLifespan" : 300,
+          "accessTokenLifespan" : 60,
           "accessTokenLifespanForImplicitFlow" : 900,
           "ssoSessionIdleTimeout" : 1800,
           "ssoSessionMaxLifespan" : 36000,


### PR DESCRIPTION
The K8s and OCP yaml files need to be consistent with what the operator does.
https://github.com/konveyor/tackle-operator/pull/107 is going to make changes to the lifespan of an access token, hence reflecting the same change in this repo.