### PR TITLE
fix(UI container workflow): Use specific version of Nodejs to be sure npm dependencies work as expected

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           repository: 'konveyor/tackle-ui'
           ref: ${{ github.event.inputs.tag }}
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
       - name: Yarn Install
         run: yarn install
       - name: Yarn Build


### PR DESCRIPTION
If we don't explicitly indicate which version of NodeJS we will use, then by default it will use the on of the OS within GH. https://github.com/konveyor/tackle/actions/runs/1692975837 Failed due to a default NodeJS version which at the moment is 16 but the UI officially is build using NodeJS 12